### PR TITLE
[Feat] 대시보드 메모 전체 조회 API 구현

### DIFF
--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -30,4 +30,24 @@ public class Label {
 
     @OneToMany(mappedBy = "label", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemoLabel> memoLabels = new ArrayList<>();
+
+    public static Label create(String name, User user) {
+        return Label.builder()
+                .name(name)
+                .user(user)
+                .build();
+    }
+
+    /**
+     * 기본 라벨 목록 생성
+     * - 최초 회원가입 시 사용
+     */
+    public static List<Label> createDefaultLabels(User user) {
+        return List.of(
+                create("SOPT", user),
+                create("학교", user),
+                create("책", user),
+                create("졸업프로젝트", user)
+        );
+    }
 }

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -1,0 +1,26 @@
+package org.project.domain.label.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.project.domain.user.entity.User;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "label")
+public class Label {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "label_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -29,6 +29,7 @@ public class Label {
     private User user;
 
     @OneToMany(mappedBy = "label", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<MemoLabel> memoLabels = new ArrayList<>();
 
     public static Label create(String name, User user) {

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -2,7 +2,11 @@ package org.project.domain.label.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.project.domain.memo.entity.MemoLabel;
 import org.project.domain.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -23,4 +27,7 @@ public class Label {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "label", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoLabel> memoLabels = new ArrayList<>();
 }

--- a/src/main/java/org/project/domain/label/repository/LabelRepository.java
+++ b/src/main/java/org/project/domain/label/repository/LabelRepository.java
@@ -1,0 +1,7 @@
+package org.project.domain.label.repository;
+
+import org.project.domain.label.entity.Label;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LabelRepository extends JpaRepository<Label, Long> {
+}

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
 import org.project.domain.memo.service.MemoService;
 import org.project.domain.user.dto.CustomUserDetails;
@@ -15,14 +16,13 @@ import org.project.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/memo")
+@RequestMapping("/api/v1/memo")
 @Tag(name = "메모", description = "메모 작성, 검색 등 API")
 public class MemoController {
 
@@ -41,5 +41,24 @@ public class MemoController {
                 .body(ApiResponse.created(response));
     }
 
+    @Operation(
+            summary = "메모 전체 조회",
+            description = """
+                    메모를 전체 조회합니다.
+                    labelIds가 전달되면 해당 라벨이 포함된 메모만 조회합니다.
+                    labelIds가 비어있으면 라벨과 관계없이 전체 조회합니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<MemoListDashboardResponse>> getMemos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) List<Long> labelIds
+    ) {
 
+        Long userId = userDetails.getUserId();
+
+        MemoListDashboardResponse response = memoService.getMemos(userId, labelIds);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -52,13 +53,21 @@ public class MemoController {
     @GetMapping
     public ResponseEntity<ApiResponse<MemoListDashboardResponse>> getMemos(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false) List<Long> labelIds
+            @RequestParam(required = false) List<Long> labelIds,
+            @RequestParam(required = false) LocalDateTime cursorCreatedAt,
+            @RequestParam(required = false) Long cursorMemoId,
+            @RequestParam(defaultValue = "20") int size
     ) {
-
-        Long userId = userDetails.getUserId();
-
-        MemoListDashboardResponse response = memoService.getMemos(userId, labelIds);
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        return ResponseEntity.ok(
+                ApiResponse.ok(
+                        memoService.getMemos(
+                                userDetails.getUserId(),
+                                labelIds,
+                                cursorCreatedAt,
+                                cursorMemoId,
+                                size
+                        )
+                )
+        );
     }
 }

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -1,0 +1,62 @@
+package org.project.domain.memo.dto.response;
+
+import org.project.domain.label.entity.Label;
+import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoLabel;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MemoListDashboardResponse(
+        List<MemoDashboardResponse> memos
+) {
+
+    public static MemoListDashboardResponse from(List<Memo> memos) {
+        return new MemoListDashboardResponse(
+                memos.stream()
+                        .map(MemoDashboardResponse::from)
+                        .toList()
+        );
+    }
+
+    public record MemoDashboardResponse(
+            Long memoId,
+            String title,
+            String content,
+            String imageUrl,
+            Boolean isPinned,
+            Boolean isAiGenerated,
+            LocalDateTime createdAt,
+            List<LabelResponse> labels
+    ) {
+
+        public static MemoDashboardResponse from(Memo memo) {
+            return new MemoDashboardResponse(
+                    memo.getId(),
+                    memo.getTitle(),
+                    memo.getContent(),
+                    memo.getImageUrl(),
+                    memo.getIsPinned(),
+                    memo.getIsAiGenerated(),
+                    memo.getCreatedAt(),
+                    memo.getMemoLabels().stream()
+                            .map(MemoLabel::getLabel)
+                            .map(LabelResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record LabelResponse(
+            Long labelId,
+            String name
+    ) {
+
+        public static LabelResponse from(Label label) {
+            return new LabelResponse(
+                    label.getId(),
+                    label.getName()
+            );
+        }
+    }
+}

--- a/src/main/java/org/project/domain/memo/entity/Memo.java
+++ b/src/main/java/org/project/domain/memo/entity/Memo.java
@@ -5,6 +5,9 @@ import lombok.*;
 import org.project.domain.user.entity.User;
 import org.project.global.entity.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -41,6 +44,9 @@ public class Memo extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "memo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoLabel> memoLabels = new ArrayList<>();
 
 
     // 일반 메모 생성

--- a/src/main/java/org/project/domain/memo/entity/Memo.java
+++ b/src/main/java/org/project/domain/memo/entity/Memo.java
@@ -46,6 +46,7 @@ public class Memo extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "memo", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<MemoLabel> memoLabels = new ArrayList<>();
 
 

--- a/src/main/java/org/project/domain/memo/entity/MemoLabel.java
+++ b/src/main/java/org/project/domain/memo/entity/MemoLabel.java
@@ -1,0 +1,37 @@
+package org.project.domain.memo.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.project.domain.label.entity.Label;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "memo_label",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"memo_id", "label_id"})
+        })
+public class MemoLabel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memo_label_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memo_id", nullable = false)
+    private Memo memo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "label_id", nullable = false)
+    private Label label;
+
+    public static MemoLabel create(Memo memo, Label label) {
+        return MemoLabel.builder()
+                .memo(memo)
+                .label(label)
+                .build();
+    }
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepository.java
@@ -1,31 +1,12 @@
 package org.project.domain.memo.repository;
 
 import org.project.domain.memo.entity.Memo;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-public interface MemoRepository extends JpaRepository<Memo,Long> {
-
-    @Query("""
-        select distinct m
-        from Memo m
-        left join fetch m.memoLabels ml
-        left join fetch ml.label
-        where m.user.id = :userId
-        order by m.createdAt desc
-    """)
-    List<Memo> findAllByUserId(Long userId);
-
-    @Query("""
-        select distinct m
-        from Memo m
-        join m.memoLabels ml
-        join ml.label l
-        where m.user.id = :userId
-          and l.id in :labelIds
-        order by m.createdAt desc
-    """)
-    List<Memo> findAllByUserIdAndLabelIds(Long userId, List<Long> labelIds);
+public interface MemoRepository extends JpaRepository<Memo,Long>, MemoRepositoryCustom {
 }

--- a/src/main/java/org/project/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepository.java
@@ -2,6 +2,30 @@ package org.project.domain.memo.repository;
 
 import org.project.domain.memo.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MemoRepository extends JpaRepository<Memo,Long> {
+
+    @Query("""
+        select distinct m
+        from Memo m
+        left join fetch m.memoLabels ml
+        left join fetch ml.label
+        where m.user.id = :userId
+        order by m.createdAt desc
+    """)
+    List<Memo> findAllByUserId(Long userId);
+
+    @Query("""
+        select distinct m
+        from Memo m
+        join m.memoLabels ml
+        join ml.label l
+        where m.user.id = :userId
+          and l.id in :labelIds
+        order by m.createdAt desc
+    """)
+    List<Memo> findAllByUserIdAndLabelIds(Long userId, List<Long> labelIds);
 }

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryCustom.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryCustom.java
@@ -1,0 +1,17 @@
+package org.project.domain.memo.repository;
+
+import org.project.domain.memo.entity.Memo;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MemoRepositoryCustom {
+    List<Memo> findMemos(
+            Long userId,
+            List<Long> labelIds,
+            LocalDateTime cursorCreatedAt,
+            Long cursorMemoId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
@@ -49,6 +49,10 @@ public class MemoRepositoryImpl implements MemoRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        if (memoIds.isEmpty()) {
+            return List.of();
+        }
+
         // 조회된 id로 실제 메모 페치조인하여 N+1 해결
         return queryFactory
                 .selectDistinct(memo)

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
@@ -30,11 +30,12 @@ public class MemoRepositoryImpl implements MemoRepositoryCustom {
         QMemoLabel memoLabel = QMemoLabel.memoLabel;
         QLabel label = QLabel.label;
 
-        return queryFactory
-                .selectDistinct(memo)
+        // 전체조회가 아닌 필요한 만큼 조회
+        List<Long> memoIds = queryFactory
+                .select(memo.id)
                 .from(memo)
-                .leftJoin(memo.memoLabels, memoLabel).fetchJoin()
-                .leftJoin(memoLabel.label, label).fetchJoin()
+                .leftJoin(memo.memoLabels, memoLabel)
+                .leftJoin(memoLabel.label, label)
                 .where(
                         memo.user.id.eq(userId),
                         labelIn(labelIds),
@@ -45,6 +46,19 @@ public class MemoRepositoryImpl implements MemoRepositoryCustom {
                         memo.id.desc()
                 )
                 .limit(pageable.getPageSize())
+                .fetch();
+
+        // 조회된 id로 실제 메모 페치조인하여 N+1 해결
+        return queryFactory
+                .selectDistinct(memo)
+                .from(memo)
+                .leftJoin(memo.memoLabels, memoLabel).fetchJoin()
+                .leftJoin(memoLabel.label, label).fetchJoin()
+                .where(memo.id.in(memoIds))
+                .orderBy(
+                        memo.createdAt.desc(),
+                        memo.id.desc()
+                )
                 .fetch();
     }
 

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
@@ -41,6 +41,7 @@ public class MemoRepositoryImpl implements MemoRepositoryCustom {
                         labelIn(labelIds),
                         cursorCondition(cursorCreatedAt, cursorMemoId)
                 )
+                .groupBy(memo.id)
                 .orderBy(
                         memo.createdAt.desc(),
                         memo.id.desc()

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
@@ -1,0 +1,80 @@
+package org.project.domain.memo.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.project.domain.label.entity.QLabel;
+import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.QMemo;
+import org.project.domain.memo.entity.QMemoLabel;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MemoRepositoryImpl implements MemoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Memo> findMemos(
+            Long userId,
+            List<Long> labelIds,
+            LocalDateTime cursorCreatedAt,
+            Long cursorMemoId,
+            Pageable pageable
+    ) {
+
+        QMemo memo = QMemo.memo;
+        QMemoLabel memoLabel = QMemoLabel.memoLabel;
+        QLabel label = QLabel.label;
+
+        return queryFactory
+                .selectDistinct(memo)
+                .from(memo)
+                .leftJoin(memo.memoLabels, memoLabel).fetchJoin()
+                .leftJoin(memoLabel.label, label).fetchJoin()
+                .where(
+                        memo.user.id.eq(userId),
+                        labelIn(labelIds),
+                        cursorCondition(cursorCreatedAt, cursorMemoId)
+                )
+                .orderBy(
+                        memo.createdAt.desc(),
+                        memo.id.desc()
+                )
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    /**
+     * labelIds가 있을 때
+     */
+    private BooleanExpression labelIn(List<Long> labelIds) {
+        if (labelIds == null || labelIds.isEmpty()) {
+            return null;
+        }
+        return QMemoLabel.memoLabel.label.id.in(labelIds);
+    }
+
+    /**
+     * 커서 조건
+     */
+    private BooleanExpression cursorCondition(
+            LocalDateTime cursorCreatedAt,
+            Long cursorMemoId
+    ) {
+        if (cursorCreatedAt == null || cursorMemoId == null) {
+            return null;
+        }
+
+        QMemo memo = QMemo.memo;
+
+        return memo.createdAt.lt(cursorCreatedAt)
+                .or(
+                        memo.createdAt.eq(cursorCreatedAt)
+                                .and(memo.id.lt(cursorMemoId))
+                );
+    }
+}

--- a/src/main/java/org/project/domain/memo/service/MemoService.java
+++ b/src/main/java/org/project/domain/memo/service/MemoService.java
@@ -1,9 +1,14 @@
 package org.project.domain.memo.service;
 
 import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
+
+import java.util.List;
 
 public interface MemoService {
 
     MemoResponse createMemo(Long userId, MemoCreateRequest request);
+
+    MemoListDashboardResponse getMemos(Long userId, List<Long> labelIds);
 }

--- a/src/main/java/org/project/domain/memo/service/MemoService.java
+++ b/src/main/java/org/project/domain/memo/service/MemoService.java
@@ -4,11 +4,18 @@ import org.project.domain.memo.dto.request.MemoCreateRequest;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MemoService {
 
     MemoResponse createMemo(Long userId, MemoCreateRequest request);
 
-    MemoListDashboardResponse getMemos(Long userId, List<Long> labelIds);
+    MemoListDashboardResponse getMemos(
+            Long userId,
+            List<Long> labelIds,
+            LocalDateTime cursorCreatedAt,
+            Long cursorMemoId,
+            int size
+    );
 }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -10,9 +10,11 @@ import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.UserErrorCode;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -37,17 +39,21 @@ public class MemoServiceImpl implements MemoService {
     }
 
     @Override
-    public MemoListDashboardResponse getMemos(Long userId, List<Long> labelIds) {
+    public MemoListDashboardResponse getMemos(
+            Long userId,
+            List<Long> labelIds,
+            LocalDateTime cursorCreatedAt,
+            Long cursorMemoId,
+            int size
+    ) {
 
-        List<Memo> memos;
-
-        if (labelIds == null || labelIds.isEmpty()) {
-            // 라벨 필터 없음 → 전체 조회
-            memos = memoRepository.findAllByUserId(userId);
-        } else {
-            // 라벨 필터 있음 → 해당 라벨 포함 메모 조회
-            memos = memoRepository.findAllByUserIdAndLabelIds(userId, labelIds);
-        }
+        List<Memo> memos = memoRepository.findMemos(
+                userId,
+                labelIds,
+                cursorCreatedAt,
+                cursorMemoId,
+                PageRequest.of(0, size)
+        );
 
         return MemoListDashboardResponse.from(memos);
     }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -2,6 +2,7 @@ package org.project.domain.memo.service;
 
 import lombok.RequiredArgsConstructor;
 import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.repository.MemoRepository;
@@ -11,6 +12,8 @@ import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.UserErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +34,21 @@ public class MemoServiceImpl implements MemoService {
         Memo savedMemo = memoRepository.save(memo);
 
         return MemoResponse.from(savedMemo);
+    }
+
+    @Override
+    public MemoListDashboardResponse getMemos(Long userId, List<Long> labelIds) {
+
+        List<Memo> memos;
+
+        if (labelIds == null || labelIds.isEmpty()) {
+            // 라벨 필터 없음 → 전체 조회
+            memos = memoRepository.findAllByUserId(userId);
+        } else {
+            // 라벨 필터 있음 → 해당 라벨 포함 메모 조회
+            memos = memoRepository.findAllByUserIdAndLabelIds(userId, labelIds);
+        }
+
+        return MemoListDashboardResponse.from(memos);
     }
 }

--- a/src/main/java/org/project/domain/user/service/GoogleAuthService.java
+++ b/src/main/java/org/project/domain/user/service/GoogleAuthService.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.project.domain.label.entity.Label;
+import org.project.domain.label.repository.LabelRepository;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.domain.user.dto.response.JwtLoginResponse;
 import org.project.domain.user.entity.User;
@@ -43,6 +45,7 @@ public class GoogleAuthService {
     private final TokenResponseBuilder tokenResponseBuilder;
     private final BlacklistTokenRepository blacklistTokenRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final LabelRepository labelRepository;
 
     public ResponseEntity<ApiResponse<Void>> loginOrRegisterWithResponse(String code,
                                                                          HttpServletResponse response) {
@@ -64,6 +67,7 @@ public class GoogleAuthService {
 
         // 2. DB에 유저 존재 여부 확인
         User user;
+        boolean isNewUser = false;
 
         Optional<User> optionalUser = userRepository.findByEmail(profile.email());
 
@@ -73,6 +77,12 @@ public class GoogleAuthService {
             user = userRepository.save(
                     User.createSocialUser(profile.email(), profile.name(), profile.picture(), "google")
             );
+            isNewUser = true;
+        }
+
+        if (isNewUser) {
+            labelRepository.saveAll(Label.createDefaultLabels(user));
+            log.info("기본 라벨 생성 완료 - userId: {}", user.getId());
         }
 
         // 3. JWT 토큰 생성
@@ -85,7 +95,7 @@ public class GoogleAuthService {
 
         refreshTokenRepository.save(refreshJti, refreshTtl);
 
-        log.info("🔑 JWT 발급 완료 - userId: {}", user.getId());
+        log.info("JWT 발급 완료 - userId: {}", user.getId());
 
         return JwtLoginResponse.of(user, serverAccessToken, serverRefreshToken);
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #16 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 대시보드에서 메모 전체 조회 API를 구현했습니다.
- 메모 전체 조회시 라벨id를 비울 경우 전체 조회
- 라벨id가 있을 경우 필터링되어 전체 조회됩니다.
- 전체조회는 기본적으로 createdAt 내림차순으로 최신순으로 정렬됩니다.
- 커서 기반 조회로 가장 마지막 메모의 createdAt, memoId 다음의 메모를 조회하는 방식으로 구현했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 신규 가입자에 대한 기본 레이블 자동 생성(SOPT, 학교, 책, 졸업프로젝트)
  * 메모-레이블 연관(태깅) 및 연관 저장 지원

* **향상**
  * 대시보드용 메모 리스트 응답 구조 추가(메모와 레이블 포함)
  * 레이블 필터 및 커서 기반 페이지네이션으로 대시보드 조회 성능·사용성 개선
  * 메모 조회용 커스텀 저장소 구현 및 서비스·응답 흐름 추가

* **API 변경**
  * 메모 관련 기본 경로를 /api/v1/memo로 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->