### PR TITLE
[Feat] 이미지/파일 추가된 메모 작성 및 전체 조회 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ dependencies {
 
     // monitoring
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // S3
+    implementation platform("software.amazon.awssdk:bom:2.25.52")
+
+    implementation "software.amazon.awssdk:s3"
+    implementation "software.amazon.awssdk:s3-presigner"
+    implementation "software.amazon.awssdk:auth"
 }
 
 def querydslDir = "src/main/generated/querydsl"

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation platform("software.amazon.awssdk:bom:2.25.52")
 
     implementation "software.amazon.awssdk:s3"
-    implementation "software.amazon.awssdk:s3-presigner"
     implementation "software.amazon.awssdk:auth"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,10 +75,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // S3
-    implementation platform("software.amazon.awssdk:bom:2.25.52")
+    implementation platform("software.amazon.awssdk:bom:2.31.68")
 
     implementation "software.amazon.awssdk:s3"
-    implementation "software.amazon.awssdk:auth"
 }
 
 def querydslDir = "src/main/generated/querydsl"

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -56,7 +56,14 @@ public class MemoController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "메모 작성", description = "일반 메모를 작성합니다.")
+    @Operation(
+            summary = "메모 작성",
+            description = """
+                메모를 작성합니다.
+                이미지/파일은 presigned URL을 통해 S3에 업로드 완료 후
+                s3Key 정보를 함께 전달해야 합니다.
+                """
+    )
     @PostMapping
     @BusinessExceptionDescription(SwaggerResponseDescription.CREATE_MEMO)
     public ResponseEntity<ApiResponse<MemoResponse>> createMemo(

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -82,30 +82,40 @@ public class MemoController {
     @Operation(
             summary = "메모 전체 조회",
             description = """
-                    메모를 전체 조회합니다.
-                    labelIds가 전달되면 해당 라벨이 포함된 메모만 조회합니다.
-                    labelIds가 비어있으면 라벨과 관계없이 전체 조회합니다.
-                    """
+                메모를 전체 조회합니다.
+                - labelIds가 있으면 해당 라벨이 포함된 메모만 조회합니다.
+                - 커서 기반 페이지네이션을 지원합니다.
+                - 각 메모는 대표 이미지 1개(presigned URL)와
+                  이미지/파일 개수 정보를 포함합니다.
+                """
     )
     @GetMapping
     public ResponseEntity<ApiResponse<MemoListDashboardResponse>> getMemos(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false) List<Long> labelIds,
-            @RequestParam(required = false) LocalDateTime cursorCreatedAt,
-            @RequestParam(required = false) Long cursorMemoId,
-            @RequestParam(defaultValue = "20") int size
+
+            @RequestParam(required = false)
+            List<Long> labelIds,
+
+            @RequestParam(required = false)
+            LocalDateTime cursorCreatedAt,
+
+            @RequestParam(required = false)
+            Long cursorMemoId,
+
+            @RequestParam(defaultValue = "20")
+            int size
     ) {
-        return ResponseEntity.ok(
-                ApiResponse.ok(
-                        memoService.getMemos(
-                                userDetails.getUserId(),
-                                labelIds,
-                                cursorCreatedAt,
-                                cursorMemoId,
-                                size
-                        )
-                )
-        );
+
+        MemoListDashboardResponse response =
+                memoService.getMemosWithMedia(
+                        userDetails.getUserId(),
+                        labelIds,
+                        cursorCreatedAt,
+                        cursorMemoId,
+                        size
+                );
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @GetMapping("/{memoId}")

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -6,9 +6,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.request.MemoPresignedUrlRequest;
 import org.project.domain.memo.dto.response.MemoDetailResponse;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;
+import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
+import org.project.domain.memo.service.MemoS3Service;
 import org.project.domain.memo.service.MemoService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.domain.user.entity.User;
@@ -30,6 +33,28 @@ import java.util.List;
 public class MemoController {
 
     private final MemoService memoService;
+    private final MemoS3Service memoS3Service;
+
+    @Operation(
+            summary = "메모 이미지/파일 presigned URL 발급",
+            description = """
+                    메모 생성 전에 S3에 업로드할 이미지/파일용 presigned PUT URL을 발급합니다.
+                    업로드 완료 후 s3Key를 메모 생성 API에 전달해야 합니다.
+                    """
+    )
+    @PostMapping("/presigned-urls")
+    public ResponseEntity<ApiResponse<MemoPresignedUrlResponse>> issuePresignedUrls(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MemoPresignedUrlRequest request
+    ) {
+
+        Long userId = userDetails.getUserId();
+
+        MemoPresignedUrlResponse response =
+                memoS3Service.issuePresignedUrls(userId, request);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 
     @Operation(summary = "메모 작성", description = "일반 메모를 작성합니다.")
     @PostMapping

--- a/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
@@ -16,7 +16,42 @@ public record MemoCreateRequest(
         String content,
 
         @Schema(description = "라벨 이름 목록", example = "[\"SOPT\", \"학교\", \"중요\"]")
-        List<String> labelNames
+        List<String> labelNames,
 
+        @Schema(description = "이미지 메타데이터 목록 (선택)")
+        List<ImageRequest> images,
+
+        @Schema(description = "파일 메타데이터 목록 (선택)")
+        List<FileRequest> files
 ) {
+
+        public record ImageRequest(
+                @Schema(description = "S3 key", example = "memo-image/1/uuid.jpg")
+                String s3Key,
+
+                @Schema(description = "파일 크기(bytes)", example = "245678")
+                Long bytes,
+
+                @Schema(description = "확장자", example = "jpg")
+                String extension,
+
+                @Schema(description = "정렬 우선순위", example = "1")
+                Integer priority
+        ) {
+        }
+
+        public record FileRequest(
+                @Schema(description = "S3 key", example = "memo-file/1/uuid.pdf")
+                String s3Key,
+
+                @Schema(description = "파일 크기(bytes)", example = "1048576")
+                Long bytes,
+
+                @Schema(description = "확장자", example = "pdf")
+                String extension,
+
+                @Schema(description = "정렬 우선순위", example = "1")
+                Integer priority
+        ) {
+        }
 }

--- a/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
@@ -15,7 +15,7 @@ public record MemoCreateRequest(
         @NotBlank(message = "내용을 입력해주세요.")
         String content,
 
-        @Schema(description = "라벨 이름 목록", example = "[\"SOPT\", \"학교\", \"중요\"]")
+        @Schema(description = "라벨 이름 목록", example = "[\"SOPT\", \"교양\", \"레퍼런스\"]")
         List<String> labelNames,
 
         @Schema(description = "이미지 메타데이터 목록 (선택)")
@@ -26,13 +26,13 @@ public record MemoCreateRequest(
 ) {
 
         public record ImageRequest(
-                @Schema(description = "S3 key", example = "memo-image/1/uuid.jpg")
+                @Schema(description = "S3 key", example = "memo-image/1/53238404-f89d-4728-9dc0-efb2a3c7787b.png")
                 String s3Key,
 
                 @Schema(description = "파일 크기(bytes)", example = "245678")
                 Long bytes,
 
-                @Schema(description = "확장자", example = "jpg")
+                @Schema(description = "확장자", example = "png")
                 String extension,
 
                 @Schema(description = "정렬 우선순위", example = "1")
@@ -41,7 +41,7 @@ public record MemoCreateRequest(
         }
 
         public record FileRequest(
-                @Schema(description = "S3 key", example = "memo-file/1/uuid.pdf")
+                @Schema(description = "S3 key", example = "memo-file/1/780fd26c-8ab7-4762-b148-b9c8c071795b.pdf")
                 String s3Key,
 
                 @Schema(description = "파일 크기(bytes)", example = "1048576")

--- a/src/main/java/org/project/domain/memo/dto/request/MemoPresignedUrlRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoPresignedUrlRequest.java
@@ -1,0 +1,22 @@
+package org.project.domain.memo.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record MemoPresignedUrlRequest(
+
+        @NotNull
+        List<UploadRequest> images,
+
+        @NotNull
+        List<UploadRequest> files
+) {
+
+    public record UploadRequest(
+            @NotNull String extension,   // jpg, png, pdf ...
+            @NotNull Long bytes,         // 파일 크기
+            @NotNull Integer priority    // 정렬용
+    ) {
+    }
+}

--- a/src/main/java/org/project/domain/memo/dto/request/MemoPresignedUrlRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoPresignedUrlRequest.java
@@ -1,22 +1,78 @@
 package org.project.domain.memo.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+@Schema(
+        name = "MemoPresignedUrlRequest",
+        description = "메모 이미지/파일 업로드용 presigned URL 발급 요청"
+)
 public record MemoPresignedUrlRequest(
 
         @NotNull
+        @Schema(
+                description = "업로드할 이미지 목록",
+                example = """
+        [
+          {
+            "extension": "jpg",
+            "bytes": 245678,
+            "priority": 1
+          },
+          {
+            "extension": "png",
+            "bytes": 532198,
+            "priority": 2
+          }
+        ]
+        """
+        )
         List<UploadRequest> images,
 
+        @Schema(
+                description = "업로드할 파일 목록",
+                example = """
+        [
+          {
+            "extension": "pdf",
+            "bytes": 1048576,
+            "priority": 1
+          }
+        ]
+        """
+        )
         @NotNull
         List<UploadRequest> files
 ) {
 
+    @Schema(
+            name = "UploadRequest",
+            description = "단일 파일 업로드 정보"
+    )
     public record UploadRequest(
-            @NotNull String extension,   // jpg, png, pdf ...
-            @NotNull Long bytes,         // 파일 크기
-            @NotNull Integer priority    // 정렬용
+
+            @NotNull
+            @Schema(
+                    description = "파일 확장자 (확장자만, dot 제외)",
+                    example = "jpg"
+            )
+            String extension,
+
+            @NotNull
+            @Schema(
+                    description = "파일 크기 (bytes)",
+                    example = "245678"
+            )
+            Long bytes,
+
+            @NotNull
+            @Schema(
+                    description = "정렬 우선순위 (낮을수록 앞)",
+                    example = "1"
+            )
+            Integer priority
     ) {
     }
 }

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -11,31 +11,49 @@ public record MemoListDashboardResponse(
         List<MemoDashboardResponse> memos
 ) {
 
-    public static MemoListDashboardResponse from(List<Memo> memos) {
-        return new MemoListDashboardResponse(
-                memos.stream()
-                        .map(MemoDashboardResponse::from)
-                        .toList()
-        );
+    public static MemoListDashboardResponse from(List<MemoDashboardResponse> memos) {
+        return new MemoListDashboardResponse(memos);
     }
 
+    /**
+     * 대시보드용 메모 응답
+     */
     public record MemoDashboardResponse(
             Long memoId,
             String title,
             String content,
-            String imageUrl,
+
+            // 대표 이미지 (priority 가장 낮은 1개, presigned URL)
+            String representativeImageUrl,
+
+            // 이미지 / 파일 개수
+            int imageCount,
+            int fileCount,
+
             Boolean isPinned,
             Boolean isAiGenerated,
             LocalDateTime createdAt,
+
             List<LabelResponse> labels
     ) {
 
-        public static MemoDashboardResponse from(Memo memo) {
+        /**
+         * 엔티티 → DTO 변환
+         * (presigned URL, count 값은 Service에서 계산 후 주입)
+         */
+        public static MemoDashboardResponse of(
+                Memo memo,
+                String representativeImageUrl,
+                int imageCount,
+                int fileCount
+        ) {
             return new MemoDashboardResponse(
                     memo.getId(),
                     memo.getTitle(),
                     memo.getContent(),
-                    memo.getImageUrl(),
+                    representativeImageUrl,
+                    imageCount,
+                    fileCount,
                     memo.getIsPinned(),
                     memo.getIsAiGenerated(),
                     memo.getCreatedAt(),
@@ -47,6 +65,9 @@ public record MemoListDashboardResponse(
         }
     }
 
+    /**
+     * 라벨 응답
+     */
     public record LabelResponse(
             Long labelId,
             String name

--- a/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
@@ -1,0 +1,19 @@
+package org.project.domain.memo.dto.response;
+
+import java.util.List;
+
+public record MemoPresignedUrlResponse(
+
+        List<PresignedUrlResponse> images,
+        List<PresignedUrlResponse> files
+) {
+
+    public record PresignedUrlResponse(
+            String s3Key,
+            String presignedUrl,
+            Long bytes,
+            String extension,
+            Integer priority
+    ) {
+    }
+}

--- a/src/main/java/org/project/domain/memo/entity/MemoFile.java
+++ b/src/main/java/org/project/domain/memo/entity/MemoFile.java
@@ -20,8 +20,8 @@ public class MemoFile {
     @JoinColumn(name = "memo_id", nullable = false)
     private Memo memo;
 
-    @Column(name = "file_url", nullable = false, length = 500)
-    private String fileUrl;
+    @Column(name = "file_S3_key", nullable = false, length = 500)
+    private String fileS3Key;
 
     @Column(name = "file_bytes")
     private Long fileBytes;

--- a/src/main/java/org/project/domain/memo/entity/MemoImage.java
+++ b/src/main/java/org/project/domain/memo/entity/MemoImage.java
@@ -20,8 +20,8 @@ public class MemoImage {
     @JoinColumn(name = "memo_id", nullable = false)
     private Memo memo;
 
-    @Column(name = "image_url", nullable = false, length = 500)
-    private String imageUrl;
+    @Column(name = "image_S3_key", nullable = false, length = 500)
+    private String imageS3Key;
 
     @Column(name = "image_bytes")
     private Long imageBytes;

--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
@@ -3,5 +3,9 @@ package org.project.domain.memo.repository;
 import org.project.domain.memo.entity.MemoFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemoFileRepository extends JpaRepository<MemoFile, Long> {
+
+    List<MemoFile> findByMemoIdIn(List<Long> memoIds);
 }

--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
@@ -1,0 +1,7 @@
+package org.project.domain.memo.repository;
+
+import org.project.domain.memo.entity.MemoFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoFileRepository extends JpaRepository<MemoFile, Long> {
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
@@ -3,5 +3,9 @@ package org.project.domain.memo.repository;
 import org.project.domain.memo.entity.MemoImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemoImageRepository extends JpaRepository<MemoImage, Long> {
+
+    List<MemoImage> findByMemoIdIn(List<Long> memoIds);
 }

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
@@ -1,0 +1,7 @@
+package org.project.domain.memo.repository;
+
+import org.project.domain.memo.entity.MemoImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoImageRepository extends JpaRepository<MemoImage, Long> {
+}

--- a/src/main/java/org/project/domain/memo/service/MemoS3Service.java
+++ b/src/main/java/org/project/domain/memo/service/MemoS3Service.java
@@ -1,0 +1,13 @@
+package org.project.domain.memo.service;
+
+
+import org.project.domain.memo.dto.request.MemoPresignedUrlRequest;
+import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
+
+public interface MemoS3Service {
+
+    MemoPresignedUrlResponse issuePresignedUrls(
+            Long userId,
+            MemoPresignedUrlRequest request
+    );
+}

--- a/src/main/java/org/project/domain/memo/service/MemoS3ServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoS3ServiceImpl.java
@@ -1,0 +1,115 @@
+package org.project.domain.memo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.domain.memo.dto.request.MemoPresignedUrlRequest;
+import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MemoS3ServiceImpl implements MemoS3Service {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public MemoPresignedUrlResponse issuePresignedUrls(
+            Long userId,
+            MemoPresignedUrlRequest request
+    ) {
+
+        List<MemoPresignedUrlResponse.PresignedUrlResponse> imageUrls =
+                request.images().stream()
+                        .map(r -> createPresignedPutUrl(
+                                userId,
+                                "memo-image",
+                                r.extension(),
+                                r.bytes(),
+                                r.priority()
+                        ))
+                        .toList();
+
+        List<MemoPresignedUrlResponse.PresignedUrlResponse> fileUrls =
+                request.files().stream()
+                        .map(r -> createPresignedPutUrl(
+                                userId,
+                                "memo-file",
+                                r.extension(),
+                                r.bytes(),
+                                r.priority()
+                        ))
+                        .toList();
+
+        return new MemoPresignedUrlResponse(imageUrls, fileUrls);
+    }
+
+    /**
+     * presigned PUT URL 생성
+     */
+    private MemoPresignedUrlResponse.PresignedUrlResponse createPresignedPutUrl(
+            Long userId,
+            String prefix,
+            String extension,
+            Long bytes,
+            Integer priority
+    ) {
+
+        String s3Key = String.format(
+                "%s/%d/%s.%s",
+                prefix,
+                userId,
+                UUID.randomUUID(),
+                extension
+        );
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .contentType(resolveContentType(extension))
+                .build();
+
+        PutObjectPresignRequest presignRequest =
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(10)) // 유효시간 10분
+                        .putObjectRequest(putObjectRequest)
+                        .build();
+
+        String presignedUrl =
+                s3Presigner.presignPutObject(presignRequest)
+                        .url()
+                        .toString();
+
+        return new MemoPresignedUrlResponse.PresignedUrlResponse(
+                s3Key,
+                presignedUrl,
+                bytes,
+                extension,
+                priority
+        );
+    }
+
+    /**
+     * 확장자 → Content-Type 매핑
+     */
+    private String resolveContentType(String extension) {
+        return switch (extension.toLowerCase()) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            case "pdf" -> "application/pdf";
+            case "txt" -> "text/plain";
+            default -> "application/octet-stream";
+        };
+    }
+}

--- a/src/main/java/org/project/domain/memo/service/MemoService.java
+++ b/src/main/java/org/project/domain/memo/service/MemoService.java
@@ -12,7 +12,7 @@ public interface MemoService {
 
     MemoResponse createMemo(Long userId, MemoCreateRequest request);
 
-    MemoListDashboardResponse getMemos(
+    MemoListDashboardResponse getMemosWithMedia(
             Long userId,
             List<Long> labelIds,
             LocalDateTime cursorCreatedAt,

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -20,6 +20,7 @@ import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.MemoErrorCode;
 import org.project.global.exception.errorcode.UserErrorCode;
 import org.project.global.util.S3PresignedUtil;
+import org.project.global.util.S3KeyUtil;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,7 @@ public class MemoServiceImpl implements MemoService {
     private final MemoFileRepository memoFileRepository;
 
     private final S3PresignedUtil s3PresignedUtil;
+    private final S3KeyUtil s3KeyUtil;
 
     @Transactional
     @Override
@@ -87,14 +89,17 @@ public class MemoServiceImpl implements MemoService {
         if (request.images() != null && !request.images().isEmpty()) {
 
             List<MemoImage> images = request.images().stream()
-                    .map(r -> MemoImage.builder()
-                            .memo(savedMemo)
-                            .imageS3Key(r.s3Key())
-                            .imageBytes(r.bytes())
-                            .imageExtension(r.extension())
-                            .imagePriority(r.priority())
-                            .build()
-                    )
+                    .map(r -> {
+                        s3KeyUtil.validateS3KeyOwner(userId, r.s3Key());
+
+                        return MemoImage.builder()
+                                .memo(savedMemo)
+                                .imageS3Key(r.s3Key())
+                                .imageBytes(r.bytes())
+                                .imageExtension(r.extension())
+                                .imagePriority(r.priority())
+                                .build();
+                    })
                     .toList();
 
             memoImageRepository.saveAll(images);
@@ -104,14 +109,17 @@ public class MemoServiceImpl implements MemoService {
         if (request.files() != null && !request.files().isEmpty()) {
 
             List<MemoFile> files = request.files().stream()
-                    .map(r -> MemoFile.builder()
-                            .memo(savedMemo)
-                            .fileS3Key(r.s3Key())
-                            .fileBytes(r.bytes())
-                            .fileExtension(r.extension())
-                            .filePriority(r.priority())
-                            .build()
-                    )
+                    .map(r -> {
+                        s3KeyUtil.validateS3KeyOwner(userId, r.s3Key());
+
+                        return MemoFile.builder()
+                                .memo(savedMemo)
+                                .fileS3Key(r.s3Key())
+                                .fileBytes(r.bytes())
+                                .fileExtension(r.extension())
+                                .filePriority(r.priority())
+                                .build();
+                    })
                     .toList();
 
             memoFileRepository.saveAll(files);

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -19,12 +19,16 @@ import org.project.global.exception.domainException.MemoException;
 import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.MemoErrorCode;
 import org.project.global.exception.errorcode.UserErrorCode;
+import org.project.global.util.S3PresignedUtil;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +41,8 @@ public class MemoServiceImpl implements MemoService {
 
     private final MemoImageRepository memoImageRepository;
     private final MemoFileRepository memoFileRepository;
+
+    private final S3PresignedUtil s3PresignedUtil;
 
     @Transactional
     @Override
@@ -114,8 +120,9 @@ public class MemoServiceImpl implements MemoService {
         return MemoResponse.from(savedMemo);
     }
 
+    @Transactional(readOnly = true)
     @Override
-    public MemoListDashboardResponse getMemos(
+    public MemoListDashboardResponse getMemosWithMedia(
             Long userId,
             List<Long> labelIds,
             LocalDateTime cursorCreatedAt,
@@ -123,6 +130,7 @@ public class MemoServiceImpl implements MemoService {
             int size
     ) {
 
+        // 메모 조회 (기존 로직 재사용)
         List<Memo> memos = memoRepository.findMemos(
                 userId,
                 labelIds,
@@ -131,7 +139,57 @@ public class MemoServiceImpl implements MemoService {
                 PageRequest.of(0, size)
         );
 
-        return MemoListDashboardResponse.from(memos);
+        if (memos.isEmpty()) {
+            return MemoListDashboardResponse.from(List.of());
+        }
+
+        // memoId 목록 추출
+        List<Long> memoIds = memos.stream()
+                .map(Memo::getId)
+                .toList();
+
+        // 이미지 / 파일 조회
+        List<MemoImage> images = memoImageRepository.findByMemoIdIn(memoIds);
+        List<MemoFile> files = memoFileRepository.findByMemoIdIn(memoIds);
+
+        // memoId 기준 그룹핑
+        Map<Long, List<MemoImage>> imageMap = images.stream()
+                .collect(Collectors.groupingBy(
+                        image -> image.getMemo().getId()
+                ));
+
+        Map<Long, List<MemoFile>> fileMap = files.stream()
+                .collect(Collectors.groupingBy(
+                        file -> file.getMemo().getId()
+                ));
+
+        // 응답 조립
+        List<MemoListDashboardResponse.MemoDashboardResponse> responses =
+                memos.stream()
+                        .map(memo -> {
+
+                            List<MemoImage> memoImages =
+                                    imageMap.getOrDefault(memo.getId(), List.of());
+
+                            List<MemoFile> memoFiles =
+                                    fileMap.getOrDefault(memo.getId(), List.of());
+
+                            // 대표 이미지 (priority ASC)
+                            String representativeImageUrl = memoImages.stream()
+                                    .min(Comparator.comparingInt(MemoImage::getImagePriority))
+                                    .map(img -> s3PresignedUtil.generateGetUrl(img.getImageS3Key()))
+                                    .orElse(null);
+
+                            return MemoListDashboardResponse.MemoDashboardResponse.of(
+                                    memo,
+                                    representativeImageUrl,
+                                    memoImages.size(),
+                                    memoFiles.size()
+                            );
+                        })
+                        .toList();
+
+        return MemoListDashboardResponse.from(responses);
     }
 
     @Override

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -8,6 +8,10 @@ import org.project.domain.memo.dto.response.MemoDetailResponse;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
 import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoFile;
+import org.project.domain.memo.entity.MemoImage;
+import org.project.domain.memo.repository.MemoFileRepository;
+import org.project.domain.memo.repository.MemoImageRepository;
 import org.project.domain.memo.repository.MemoRepository;
 import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
@@ -31,35 +35,81 @@ public class MemoServiceImpl implements MemoService {
     private final UserRepository userRepository;
     private final LabelRepository labelRepository;
 
+    private final MemoImageRepository memoImageRepository;
+    private final MemoFileRepository memoFileRepository;
+
     @Transactional
     @Override
     public MemoResponse createMemo(Long userId, MemoCreateRequest request) {
 
+        // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
 
-        Memo memo = Memo.createMemo(request.title(), request.content(), user);
+        // 메모 생성
+        Memo memo = Memo.createMemo(
+                request.title(),
+                request.content(),
+                user
+        );
 
+        // 라벨 처리 (중복 제거 + 우선순위)
         if (request.labelNames() != null && !request.labelNames().isEmpty()) {
+
             List<String> uniqueLabelNames = request.labelNames().stream()
                     .distinct()
                     .toList();
 
-            for (int i = 0; i < uniqueLabelNames.size(); i++) {
-                String labelName = uniqueLabelNames.get(i);
+            for (int priority = 0; priority < uniqueLabelNames.size(); priority++) {
+                String labelName = uniqueLabelNames.get(priority);
 
-                // 해당 유저의 라벨 찾기 (없으면 생성)
                 Label label = labelRepository.findByNameAndUser(labelName, user)
-                        .orElseGet(() -> labelRepository.save(
-                                Label.create(labelName, user)
-                        ));
+                        .orElseGet(() ->
+                                labelRepository.save(
+                                        Label.create(labelName, user)
+                                )
+                        );
 
-                // i가 우선순위임 (0, 1, 2, ...)
-                memo.addLabel(label, i);
+                memo.addLabel(label, priority);
             }
         }
 
+        // 메모 저장
         Memo savedMemo = memoRepository.save(memo);
+
+        // 이미지 메타데이터 저장 (optional)
+        if (request.images() != null && !request.images().isEmpty()) {
+
+            List<MemoImage> images = request.images().stream()
+                    .map(r -> MemoImage.builder()
+                            .memo(savedMemo)
+                            .imageS3Key(r.s3Key())
+                            .imageBytes(r.bytes())
+                            .imageExtension(r.extension())
+                            .imagePriority(r.priority())
+                            .build()
+                    )
+                    .toList();
+
+            memoImageRepository.saveAll(images);
+        }
+
+        // 파일 메타데이터 저장 (optional)
+        if (request.files() != null && !request.files().isEmpty()) {
+
+            List<MemoFile> files = request.files().stream()
+                    .map(r -> MemoFile.builder()
+                            .memo(savedMemo)
+                            .fileS3Key(r.s3Key())
+                            .fileBytes(r.bytes())
+                            .fileExtension(r.extension())
+                            .filePriority(r.priority())
+                            .build()
+                    )
+                    .toList();
+
+            memoFileRepository.saveAll(files);
+        }
 
         return MemoResponse.from(savedMemo);
     }

--- a/src/main/java/org/project/global/config/S3Config.java
+++ b/src/main/java/org/project/global/config/S3Config.java
@@ -1,0 +1,19 @@
+package org.project.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
@@ -8,7 +8,7 @@ public enum MemoErrorCode implements ErrorCode {
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND,404,"해당 메모를 찾을 수 없습니다."),
     FORBIDDEN_MEMO(HttpStatus.FORBIDDEN, 403, "해당 메모에 접근할 권한이 없습니다."),
     INVALID_S3_KEY_FORMAT(HttpStatus.BAD_REQUEST, 400, "S3 키 형식이 올바르지 않습니다."),
-    S3_KEY_USER_MISMATCH(HttpStatus.FORBIDDEN, 403, "요청한 사용자와 S3 리소스 소유자가 일치하지 않습니다.");;
+    S3_KEY_USER_MISMATCH(HttpStatus.FORBIDDEN, 403, "요청한 사용자와 S3 리소스 소유자가 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum MemoErrorCode implements ErrorCode {
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND,404,"해당 메모를 찾을 수 없습니다."),
-    FORBIDDEN_MEMO(HttpStatus.FORBIDDEN, 403, "해당 메모에 접근할 권한이 없습니다.");
+    FORBIDDEN_MEMO(HttpStatus.FORBIDDEN, 403, "해당 메모에 접근할 권한이 없습니다."),
+    INVALID_S3_KEY_FORMAT(HttpStatus.BAD_REQUEST, 400, "S3 키 형식이 올바르지 않습니다."),
+    S3_KEY_USER_MISMATCH(HttpStatus.FORBIDDEN, 403, "요청한 사용자와 S3 리소스 소유자가 일치하지 않습니다.");;
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/org/project/global/util/S3KeyUtil.java
+++ b/src/main/java/org/project/global/util/S3KeyUtil.java
@@ -1,0 +1,38 @@
+package org.project.global.util;
+
+import org.project.global.exception.domainException.MemoException;
+import org.project.global.exception.errorcode.MemoErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class S3KeyUtil {
+
+    public Long extractUserIdFromS3Key(String s3Key) {
+        // memo-image/1/uuid.jpg
+        // memo-file/1/uuid.pdf
+
+        if (s3Key == null || s3Key.isBlank()) {
+            throw new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        try {
+            String[] parts = s3Key.split("/");
+
+            if (parts.length < 2) {
+                throw new IllegalArgumentException();
+            }
+
+            return Long.parseLong(parts[1]); // index 1 = userId
+        } catch (Exception e) {
+            throw new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+    }
+
+    public void validateS3KeyOwner(Long requestUserId, String s3Key) {
+        Long ownerId = extractUserIdFromS3Key(s3Key);
+
+        if (!ownerId.equals(requestUserId)) {
+            throw new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/org/project/global/util/S3PresignedUtil.java
+++ b/src/main/java/org/project/global/util/S3PresignedUtil.java
@@ -1,0 +1,41 @@
+package org.project.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUtil {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * presigned GET URL 생성
+     */
+    public String generateGetUrl(String s3Key) {
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .build();
+
+        GetObjectPresignRequest presignRequest =
+                GetObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofHours(24)) // GET URL 유효시간
+                        .getObjectRequest(getObjectRequest)
+                        .build();
+
+        return s3Presigner.presignGetObject(presignRequest)
+                .url()
+                .toString();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,3 +59,8 @@ app:
     domain: ".clustar.cloud"
     same-site: None
     secure: true
+
+cloud:
+  aws:
+    s3:
+      bucket: clustar-bucket-01


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #23 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 메모 작성
  - 이미지 생성 전 10분 동안 사용 가능한 S3 PUT Presigned URL과 S3key를 응답합니다.
  - 메모 작성시 이미지/파일을 저장한 S3key를 요청값에 포함합니다.
  - 메모 작성 성공시, DB에는 S3key를 저장합니다.
- 메모 전체 조회
  - 메모 전체 조회시 이미지 S3 GET Presigned URL과 이미지/파일 개수를 포함하여 응답합니다.
  - 메모와 연결된 이미지 중 우선순위가 가장 높은(가장 작은) 이미지의 S3key로 24시간 동안 사용 가능한 S3 GET Presigned URL을 응답합니다

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AWS S3 연동 추가 및 presigned URL 발급을 통한 클라이언트 업로드 지원(엔드포인트 추가)
  * 메모 작성 시 다중 이미지/파일 메타데이터 저장 기능
  * 메모 목록에 대표 이미지(썸네일)와 이미지/파일 개수 노출

* **버그 수정 / 오류 처리**
  * S3 키 형식 및 소유자 검증 로직과 이에 따른 오류 코드 추가

* **설정**
  * 로컬 환경용 S3 버킷 설정 항목 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->