### PR TITLE
chore: 데이터 일관성 문제 해결

### DIFF
--- a/src/main/java/org/project/domain/memo/event/MemoDeletedEvent.java
+++ b/src/main/java/org/project/domain/memo/event/MemoDeletedEvent.java
@@ -1,0 +1,14 @@
+package org.project.domain.memo.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class MemoDeletedEvent {
+    private final Long memoId;
+    private final List<String> imageKeys;
+    private final List<String> fileKeys;
+}

--- a/src/main/java/org/project/domain/memo/event/MemoEventListener.java
+++ b/src/main/java/org/project/domain/memo/event/MemoEventListener.java
@@ -1,0 +1,26 @@
+package org.project.domain.memo.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.global.util.S3Util;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemoEventListener {
+    private final S3Util s3Util;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMemoDeleted(MemoDeletedEvent event) {
+        log.info("메모 삭제 완료 - S3 파일 삭제 시작: memoId={}", event.getMemoId());
+
+        event.getImageKeys().forEach(s3Util::deleteFile);
+        event.getFileKeys().forEach(s3Util::deleteFile);
+
+        log.info("S3 파일 삭제 완료: memoId={}", event.getMemoId());
+    }
+
+}

--- a/src/main/java/org/project/domain/memo/event/MemoEventListener.java
+++ b/src/main/java/org/project/domain/memo/event/MemoEventListener.java
@@ -2,7 +2,6 @@ package org.project.domain.memo.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.project.global.util.S3Util;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -11,14 +10,18 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class MemoEventListener {
-    private final S3Util s3Util;
+    private final S3DeletionHandler s3DeletionHandler;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemoDeleted(MemoDeletedEvent event) {
         log.info("메모 삭제 완료 - S3 파일 삭제 시작: memoId={}", event.getMemoId());
 
-        event.getImageKeys().forEach(s3Util::deleteFile);
-        event.getFileKeys().forEach(s3Util::deleteFile);
+        event.getImageKeys().forEach(key ->
+                s3DeletionHandler.deleteOrRecord(key, event.getMemoId(), "image")
+        );
+        event.getFileKeys().forEach(key ->
+                s3DeletionHandler.deleteOrRecord(key, event.getMemoId(), "file")
+        );
 
         log.info("S3 파일 삭제 완료: memoId={}", event.getMemoId());
     }

--- a/src/main/java/org/project/domain/memo/event/S3DeletionHandler.java
+++ b/src/main/java/org/project/domain/memo/event/S3DeletionHandler.java
@@ -1,0 +1,40 @@
+package org.project.domain.memo.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.domain.s3.entity.S3DeletionFailure;
+import org.project.domain.s3.repository.S3DeletionFailureRepository;
+import org.project.global.util.S3Util;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3DeletionHandler {
+    private final S3Util s3Util;
+    private final S3DeletionFailureRepository failureRepository;
+
+    // 호출될 때마다 무조건 새 트랜잭션을 열어서 실패 기록을 DB에 커밋함
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteOrRecord(String key, Long memoId, String fileType) {
+        try {
+            s3Util.deleteFile(key);
+            log.info("S3 삭제 성공: {}", key);
+        } catch (Exception e) {
+            log.error("S3 삭제 실패 - DB 기록 저장: {}", key);
+            S3DeletionFailure failure = S3DeletionFailure.builder()
+                    .s3Key(key)
+                    .memoId(memoId)
+                    .fileType(fileType)
+                    .failedAt(LocalDateTime.now())
+                    .errorMessage(e.getMessage())
+                    .isResolved(false)
+                    .build();
+            failureRepository.save(failure);
+        }
+    }
+}

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -12,6 +12,7 @@ import org.project.domain.memo.dto.response.MemoResponse;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoFile;
 import org.project.domain.memo.entity.MemoImage;
+import org.project.domain.memo.event.MemoDeletedEvent;
 import org.project.domain.memo.repository.MemoFileRepository;
 import org.project.domain.memo.repository.MemoImageRepository;
 import org.project.domain.memo.repository.MemoLabelRepository;
@@ -24,6 +25,7 @@ import org.project.global.exception.errorcode.MemoErrorCode;
 import org.project.global.exception.errorcode.UserErrorCode;
 import org.project.global.util.S3KeyUtil;
 import org.project.global.util.S3Util;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +52,8 @@ public class MemoServiceImpl implements MemoService {
 
     private final S3KeyUtil s3KeyUtil;
     private final S3Util s3Util;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     public MemoPresignedUrlResponse issuePresignedUrls(
             Long userId,
@@ -281,15 +285,23 @@ public class MemoServiceImpl implements MemoService {
             s3Util.deleteFile(memoImage.getImageS3Key());
         });
 
-        memo.getMemoFiles().forEach(memoFile -> {
-            s3Util.deleteFile(memoFile.getFileS3Key());
-        });
+        // 삭제할 S3 키 수집
+        List<String> imageKeys = memo.getMemoImages().stream()
+                        .map(MemoImage::getImageS3Key)
+                                .toList();
 
-        // 연관 엔티티들 hard delete
+        List<String> fileKeys = memo.getMemoFiles().stream()
+                        .map(MemoFile::getFileS3Key)
+                                .toList();
+
+        // DB 삭제 hard/soft delete
         memoImageRepository.deleteByMemo(memo);
         memoFileRepository.deleteByMemo(memo);
         memoLabelRepository.deleteByMemo(memo);
-
         memo.delete();
+
+        // 이벤트 발행(트랜잭션 커밋 후 실행됨)
+        eventPublisher.publishEvent(new MemoDeletedEvent(memoId, imageKeys, fileKeys));
     }
+
 }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -280,11 +280,6 @@ public class MemoServiceImpl implements MemoService {
             throw new MemoException(MemoErrorCode.FORBIDDEN_MEMO);
         }
 
-        // S3 파일들 삭제
-        memo.getMemoImages().forEach(memoImage -> {
-            s3Util.deleteFile(memoImage.getImageS3Key());
-        });
-
         // 삭제할 S3 키 수집
         List<String> imageKeys = memo.getMemoImages().stream()
                         .map(MemoImage::getImageS3Key)

--- a/src/main/java/org/project/domain/s3/entity/S3DeletionFailure.java
+++ b/src/main/java/org/project/domain/s3/entity/S3DeletionFailure.java
@@ -1,0 +1,39 @@
+package org.project.domain.s3.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "s3_deletion_failure")
+public class S3DeletionFailure {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "s3_deletion_failure_id")
+    private Long id;
+
+    @Column(name = "s3_key", nullable = false, length = 500)
+    private String s3Key;
+
+    @Column(name = "memo_id")
+    private Long memoId;
+
+    @Column(name = "file_type", nullable = false, length = 20)
+    private String fileType; // "image" or "file"
+
+    @Column(name = "failed_at", nullable = false)
+    private LocalDateTime failedAt;
+
+    @Column(name = "error_message", length = 500) // 에러 메시지 길이 제한
+    private String errorMessage;
+
+    @Column(name = "is_resolved", nullable = false)
+    @Builder.Default
+    private Boolean isResolved = false;
+}

--- a/src/main/java/org/project/domain/s3/repository/S3DeletionFailureRepository.java
+++ b/src/main/java/org/project/domain/s3/repository/S3DeletionFailureRepository.java
@@ -1,0 +1,7 @@
+package org.project.domain.s3.repository;
+
+import org.project.domain.s3.entity.S3DeletionFailure;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface S3DeletionFailureRepository extends JpaRepository<S3DeletionFailure, Long> {
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #30 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 이벤트 리스너를 활용하여 DB 삭제가 완료 되었을 시에 S3가 삭제되도록 하였습니다
- 또한 S3에서 삭제 실패 시 그 삭제기록을 추적할 수 있는 엔티티를 만들었습니다.

- [🔗 노션 정리 링크 바로가기](https://www.notion.so/S3-DB-2e7e58c2d57c8054ba7ff6a25ce162fc?source=copy_link)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 메모 삭제 후 연결된 이미지·첨부파일 삭제를 처리하는 이벤트 기반 비동기 정리 기능을 추가했습니다.
  * S3 삭제 실패를 기록하는 저장소가 추가되어 실패 이력 확인 및 재처리가 가능해졌습니다.

* **개선사항**
  * 메모 삭제 흐름이 정리되어 삭제 작업의 안정성과 가시성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->