### PR TITLE
[Test] 메모 생성 및 전체 조회 API & 구글 로그인 관련 API 서비스 레이어 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,10 @@ dependencies {
 
     // S3
     implementation platform("software.amazon.awssdk:bom:2.31.68")
-
     implementation "software.amazon.awssdk:s3"
+
+    // test h2
+    testImplementation 'com.h2database:h2'
 }
 
 def querydslDir = "src/main/generated/querydsl"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,27 +4,62 @@ spring:
 
   config:
     activate:
-      on-profile: test  # 테스트
+      on-profile: test
 
   datasource:
-    url: ${TEST_DB_URL}
-    username: ${TEST_DB_USERNAME}
-    password: ${TEST_DB_PASSWORD}
-#    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=PostgreSQL
+    username: sa
+    password:
 
   jpa:
     hibernate:
       ddl-auto: create-drop
+    show-sql: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        format_sql: false
-    show-sql: false
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
   h2:
     console:
       enabled: false
 
-  web:
-    resources:
-      add-mappings: false
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            redirect-uri: http://localhost/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret-key: test-secret-key-test-secret-key-test-secret-key
+  expire-length: 3600000 # 60분
+  refresh-expire-length: 3600000 # 1시간
+  header: Authorization
+
+app:
+  cookie:
+    domain: ".clustar.cloud"
+    same-site: None
+    secure: true
+
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket

--- a/src/test/java/org/project/MainApplicationTest.java
+++ b/src/test/java/org/project/MainApplicationTest.java
@@ -1,0 +1,19 @@
+package org.project;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@ActiveProfiles("test")
+@DisplayName("테스트 환경 Health Check")
+@SpringBootTest
+class MainApplicationTest {
+
+    @Test
+    @DisplayName("테스트 환경이 정상적으로 작동하는지 확인합니다")
+    void contextLoads() {
+    }
+
+}

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest/MemoServiceImplTest.java
@@ -1,0 +1,505 @@
+package org.project.domain.memo.service.MemoServiceImplTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.response.MemoListDashboardResponse;
+import org.project.domain.memo.dto.response.MemoResponse;
+import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoFile;
+import org.project.domain.memo.entity.MemoImage;
+import org.project.domain.memo.repository.MemoFileRepository;
+import org.project.domain.memo.repository.MemoImageRepository;
+import org.project.domain.memo.repository.MemoLabelRepository;
+import org.project.domain.memo.repository.MemoRepository;
+import org.project.domain.memo.service.MemoServiceImpl;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.exception.domainException.MemoException;
+import org.project.global.exception.errorcode.MemoErrorCode;
+import org.project.global.util.S3KeyUtil;
+import org.project.global.util.S3Util;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemoServiceImplTest")
+class MemoServiceImplTest {
+
+    @InjectMocks
+    private MemoServiceImpl memoService;
+
+    @Mock private MemoRepository memoRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private LabelRepository labelRepository;
+
+    @Mock private MemoImageRepository memoImageRepository;
+    @Mock private MemoFileRepository memoFileRepository;
+    @Mock private MemoLabelRepository memoLabelRepository;
+
+    @Mock private S3KeyUtil s3KeyUtil;
+    @Mock private S3Util s3Util;
+
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    // 공통 테스트 데이터
+    private User user;
+    private MemoCreateRequest request;
+
+    @Nested
+    @DisplayName("createMemo")
+    class CreateMemo {
+
+        @BeforeEach
+        void setUp() {
+            // 사용자 더미
+            user = User.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .build();
+
+            // 요청 DTO 더미
+            request = new MemoCreateRequest(
+                    "테스트 제목",
+                    "테스트 내용",
+                    List.of("SOPT", "TEST"),
+                    List.of(), // images
+                    List.of()  // files
+            );
+
+            MemoCreateRequest.ImageRequest imageRequest =
+                    new MemoCreateRequest.ImageRequest(
+                            "memo-image/1/test.png",
+                            "test.png",
+                            1024L,
+                            "png",
+                            1
+                    );
+
+            MemoCreateRequest.FileRequest fileRequest =
+                    new MemoCreateRequest.FileRequest(
+                            "memo-file/1/test.pdf",
+                            "test.pdf",
+                            2048L,
+                            "pdf",
+                            1
+                    );
+
+            request = new MemoCreateRequest(
+                    "테스트 제목",
+                    "테스트 내용",
+                    List.of("SOPT"),
+                    List.of(imageRequest),
+                    List.of(fileRequest)
+            );
+        }
+
+        @Test
+        @DisplayName("메모 생성 성공")
+        void createMemo_success() {
+            // given
+            when(userRepository.findById(user.getId()))
+                    .thenReturn(Optional.of(user));
+
+            when(memoRepository.save(any(Memo.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            MemoResponse response = memoService.createMemo(user.getId(), request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.title()).isEqualTo("테스트 제목");
+
+            verify(userRepository, times(1)).findById(user.getId());
+            verify(memoRepository, times(1)).save(any(Memo.class));
+        }
+
+        @Test
+        @DisplayName("메모 생성 실패 - 사용자가 존재하지 않음")
+        void createMemo_fail_userNotFound() {
+            // given
+            when(userRepository.findById(user.getId()))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(user.getId(), request))
+                    .isInstanceOf(RuntimeException.class);
+            // 실제 예외 타입 있으면 그걸로 교체 (ex. UserException)
+
+            verify(userRepository, times(1)).findById(user.getId());
+            verify(memoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("메모 생성 실패 - 라벨 저장 중 예외 발생")
+        void createMemo_fail_labelError() {
+            // given
+            when(userRepository.findById(user.getId()))
+                    .thenReturn(Optional.of(user));
+
+            when(labelRepository.findByNameAndUser(anyString(), any()))
+                    .thenThrow(new RuntimeException("라벨 오류"));
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(user.getId(), request))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(memoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("메모 생성 시 이미지와 파일 메타데이터가 함께 저장된다")
+        void createMemo_withImagesAndFiles_success() {
+            // given
+            when(userRepository.findById(user.getId()))
+                    .thenReturn(Optional.of(user));
+
+            when(memoRepository.save(any(Memo.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            MemoResponse response = memoService.createMemo(user.getId(), request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.title()).isEqualTo("테스트 제목");
+
+            verify(memoRepository, times(1)).save(any(Memo.class));
+
+            // 이미지 저장 검증
+            verify(memoImageRepository, times(1))
+                    .saveAll(anyList());
+
+            // 파일 저장 검증
+            verify(memoFileRepository, times(1))
+                    .saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("S3Key 검증 실패 시 예외 발생하고 트랜잭션 롤백된다")
+        void createMemo_fail_whenInvalidS3Key_thenRollback() {
+            // given
+            Long userId = 1L;
+
+            User user = User.builder()
+                    .id(userId)
+                    .email("test@test.com")
+                    .build();
+
+            MemoCreateRequest.ImageRequest imageRequest =
+                    new MemoCreateRequest.ImageRequest(
+                            "memo-image/999/invalid.png",
+                            "invalid.png",
+                            1024L,
+                            "png",
+                            1
+                    );
+
+            MemoCreateRequest request = new MemoCreateRequest(
+                    "제목",
+                    "내용",
+                    List.of("SOPT"),
+                    List.of(imageRequest),
+                    List.of()
+            );
+
+            // 사용자 조회 OK
+            when(userRepository.findById(userId))
+                    .thenReturn(Optional.of(user));
+
+            // memo save는 호출되지만
+            when(memoRepository.save(any(Memo.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // S3Key 검증 실패 강제
+            doThrow(new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH))
+                    .when(s3KeyUtil)
+                    .validateS3KeyOwner(eq(userId), anyString());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(userId, request))
+                    .isInstanceOf(MemoException.class)
+                    .hasMessage(MemoErrorCode.S3_KEY_USER_MISMATCH.getMsg());
+
+            // 메모 저장은 시도됨
+            verify(memoRepository, times(1)).save(any(Memo.class));
+
+            // 이미지/파일 저장 로직은 중단됨
+            verify(memoImageRepository, never()).saveAll(any());
+            verify(memoFileRepository, never()).saveAll(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMemosWithMedia")
+    class GetMemosWithMedia {
+
+        private User user;
+        private Memo memo1;
+        private Memo memo2;
+
+        private MemoImage image1;
+        private MemoFile file1;
+
+        @BeforeEach
+        void setUp() {
+            user = User.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .build();
+
+            memo1 = Memo.builder()
+                    .id(1L)
+                    .title("메모1")
+                    .content("내용1")
+                    .user(user)
+                    .isDeleted(false)
+                    .build();
+
+            memo2 = Memo.builder()
+                    .id(2L)
+                    .title("메모2")
+                    .content("내용2")
+                    .user(user)
+                    .isDeleted(false)
+                    .build();
+
+            image1 = MemoImage.builder()
+                    .id(10L)
+                    .memo(memo1)
+                    .imageS3Key("memo-image/1/img.png")
+                    .imagePriority(1)
+                    .build();
+
+            file1 = MemoFile.builder()
+                    .id(20L)
+                    .memo(memo1)
+                    .fileS3Key("memo-file/1/file.pdf")
+                    .filePriority(1)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("성공: 메모 + 이미지 + 파일을 함께 조회한다")
+        void success() {
+            // given
+            when(memoRepository.findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            )).thenReturn(List.of(memo1, memo2));
+
+            when(memoImageRepository.findByMemoIdIn(List.of(1L, 2L)))
+                    .thenReturn(List.of(image1));
+
+            when(memoFileRepository.findByMemoIdIn(List.of(1L, 2L)))
+                    .thenReturn(List.of(file1));
+
+            // when
+            MemoListDashboardResponse response =
+                    memoService.getMemosWithMedia(
+                            user.getId(),
+                            null,
+                            null,
+                            null,
+                            10
+                    );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.memos()).hasSize(2);
+
+            MemoListDashboardResponse.MemoDashboardResponse memoResponse =
+                    response.memos().get(0);
+
+            assertThat(memoResponse.memoId()).isEqualTo(1L);
+            assertThat(memoResponse.title()).isEqualTo("메모1");
+            assertThat(memoResponse.imageCount()).isEqualTo(1);
+            assertThat(memoResponse.fileCount()).isEqualTo(1);
+
+            // repository 호출 검증
+            verify(memoRepository).findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            );
+
+            verify(memoImageRepository).findByMemoIdIn(List.of(1L, 2L));
+            verify(memoFileRepository).findByMemoIdIn(List.of(1L, 2L));
+        }
+
+        @Test
+        @DisplayName("성공: 메모가 없으면 빈 응답을 반환한다")
+        void success_emptyMemos() {
+            // given
+            when(memoRepository.findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            )).thenReturn(List.of());
+
+            // when
+            MemoListDashboardResponse response =
+                    memoService.getMemosWithMedia(
+                            user.getId(),
+                            null,
+                            null,
+                            null,
+                            10
+                    );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.memos()).isEmpty();
+
+            // 메모만 조회되고, 미디어 조회는 안 됨
+            verify(memoRepository).findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            );
+            verifyNoInteractions(memoImageRepository);
+            verifyNoInteractions(memoFileRepository);
+        }
+
+        @Test
+        @DisplayName("성공: 이미지만 있고 파일은 없는 경우")
+        void success_onlyImages() {
+            // given
+            when(memoRepository.findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            )).thenReturn(List.of(memo1));
+
+            when(memoImageRepository.findByMemoIdIn(List.of(1L)))
+                    .thenReturn(List.of(image1));
+
+            when(memoFileRepository.findByMemoIdIn(List.of(1L)))
+                    .thenReturn(List.of()); // 파일 없음
+
+            // when
+            MemoListDashboardResponse response =
+                    memoService.getMemosWithMedia(
+                            user.getId(),
+                            null,
+                            null,
+                            null,
+                            10
+                    );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.memos()).hasSize(1);
+
+            MemoListDashboardResponse.MemoDashboardResponse memoResponse =
+                    response.memos().get(0);
+
+            assertThat(memoResponse.memoId()).isEqualTo(1L);
+            assertThat(memoResponse.imageCount()).isEqualTo(1);
+            assertThat(memoResponse.fileCount()).isEqualTo(0);
+
+            verify(memoRepository).findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    isNull(),
+                    isNull(),
+                    any(PageRequest.class)
+            );
+            verify(memoImageRepository).findByMemoIdIn(List.of(1L));
+            verify(memoFileRepository).findByMemoIdIn(List.of(1L));
+        }
+
+        @Test
+        @DisplayName("성공: cursorCreatedAt + cursorMemoId 기준으로 다음 페이지를 조회한다")
+        void success_cursorPagination() {
+            // given
+            LocalDateTime cursorCreatedAt =
+                    LocalDateTime.of(2026, 1, 13, 11, 0);
+            Long cursorMemoId = 2L;
+
+            Memo nextMemo = Memo.builder()
+                    .id(1L)
+                    .title("다음 페이지 메모")
+                    .content("내용")
+                    .user(user)
+                    .build();
+
+            ReflectionTestUtils.setField(
+                    nextMemo,
+                    "createdAt",
+                    LocalDateTime.of(2026, 1, 13, 10, 0)
+            );
+
+            when(memoRepository.findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    eq(cursorCreatedAt),
+                    eq(cursorMemoId),
+                    any(PageRequest.class)
+            )).thenReturn(List.of(nextMemo));
+
+            when(memoImageRepository.findByMemoIdIn(List.of(1L)))
+                    .thenReturn(List.of());
+
+            when(memoFileRepository.findByMemoIdIn(List.of(1L)))
+                    .thenReturn(List.of());
+
+            // when
+            MemoListDashboardResponse response =
+                    memoService.getMemosWithMedia(
+                            user.getId(),
+                            null,
+                            cursorCreatedAt,
+                            cursorMemoId,
+                            10
+                    );
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.memos()).hasSize(1);
+
+            MemoListDashboardResponse.MemoDashboardResponse memoResponse =
+                    response.memos().get(0);
+
+            assertThat(memoResponse.memoId()).isEqualTo(1L);
+            assertThat(memoResponse.title()).isEqualTo("다음 페이지 메모");
+
+            verify(memoRepository).findMemos(
+                    eq(user.getId()),
+                    isNull(),
+                    eq(cursorCreatedAt),
+                    eq(cursorMemoId),
+                    any(PageRequest.class)
+            );
+        }
+    }
+}

--- a/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
+++ b/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
@@ -1,0 +1,453 @@
+package org.project.domain.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.user.dto.CustomUserDetails;
+import org.project.domain.user.dto.response.JwtLoginResponse;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.BlacklistTokenRepository;
+import org.project.domain.user.repository.RefreshTokenRepository;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.security.CookieConfig;
+import org.project.global.response.ApiResponse;
+import org.project.global.security.client.GoogleClient;
+import org.project.global.security.client.dto.GoogleAccountProfileResponse;
+import org.project.global.security.properties.JwtProperties;
+import org.project.global.util.CookieUtil;
+import org.project.global.util.JWTUtil;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GoogleAuthService 테스트")
+class GoogleAuthServiceTest {
+
+    @InjectMocks
+    private GoogleAuthService googleAuthService;
+
+    @Mock private GoogleClient googleClient;
+    @Mock private UserRepository userRepository;
+    @Mock private JWTUtil jwtUtil;
+    @Mock private JwtProperties jwtProperties;
+    @Mock private CookieConfig cookieConfig;
+
+    @Mock private org.project.global.util.TokenResponseBuilder tokenResponseBuilder;
+    @Mock private BlacklistTokenRepository blacklistTokenRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private LabelRepository labelRepository;
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+
+    @Mock private CustomUserDetails userDetails;
+
+    private GoogleAccountProfileResponse profile;
+    private User user;
+
+    @Nested
+    @DisplayName("loginOrRegister")
+    class loginOrRegister {
+
+        @BeforeEach
+        void setUp() {
+            profile = new GoogleAccountProfileResponse(
+                    "google-sub",
+                    "홍길동",
+                    "길동",
+                    "홍",
+                    "https://image.url",
+                    "test@test.com",
+                    true,
+                    "ko"
+            );
+
+            user = User.builder()
+                    .id(1L)
+                    .email(profile.email())
+                    .name(profile.name())
+                    .profileImageUrl(profile.picture())
+                    .build();
+        }
+
+        @Test
+        @DisplayName("기존 유저면 회원가입 없이 JWT만 발급된다")
+        void login_existing_user_success() {
+            // given
+            when(googleClient.getGoogleAccountProfile(any()))
+                    .thenReturn(profile);
+
+            when(userRepository.findByEmail(profile.email()))
+                    .thenReturn(Optional.of(user));
+
+            when(jwtUtil.generateAccessToken(user.getId()))
+                    .thenReturn("access-token");
+
+            when(jwtUtil.generateRefreshToken(user.getId()))
+                    .thenReturn("refresh-token");
+
+            when(jwtUtil.getJti("refresh-token"))
+                    .thenReturn("refresh-jti");
+
+            when(jwtUtil.getRemainingExpiration("refresh-token"))
+                    .thenReturn(1000L);
+
+            // when
+            JwtLoginResponse response =
+                    googleAuthService.loginOrRegister("google-code");
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.accessToken()).isEqualTo("access-token");
+            assertThat(response.refreshToken()).isEqualTo("refresh-token");
+            assertThat(response.name()).isEqualTo(user.getName());
+            assertThat(response.profileImageUrl()).isEqualTo(user.getProfileImageUrl());
+
+            verify(labelRepository, never()).saveAll(any());
+            verify(refreshTokenRepository, times(1))
+                    .save("refresh-jti", 1000L);
+        }
+
+        @Test
+        @DisplayName("신규 유저면 회원 생성 + 기본 라벨 생성 + JWT 발급")
+        void login_new_user_success() {
+            // given
+            when(googleClient.getGoogleAccountProfile(any()))
+                    .thenReturn(profile);
+
+            when(userRepository.findByEmail(profile.email()))
+                    .thenReturn(Optional.empty());
+
+            when(userRepository.save(any(User.class)))
+                    .thenReturn(user);
+
+            when(jwtUtil.generateAccessToken(user.getId()))
+                    .thenReturn("access-token");
+
+            when(jwtUtil.generateRefreshToken(user.getId()))
+                    .thenReturn("refresh-token");
+
+            when(jwtUtil.getJti("refresh-token"))
+                    .thenReturn("refresh-jti");
+
+            when(jwtUtil.getRemainingExpiration("refresh-token"))
+                    .thenReturn(1000L);
+
+            // when
+            JwtLoginResponse response =
+                    googleAuthService.loginOrRegister("google-code");
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.accessToken()).isEqualTo("access-token");
+
+            verify(userRepository, times(1)).save(any(User.class));
+            verify(labelRepository, times(1)).saveAll(any(List.class));
+            verify(refreshTokenRepository, times(1))
+                    .save("refresh-jti", 1000L);
+        }
+
+        @Test
+        @DisplayName("GoogleClient 예외 발생 시 로그인 실패")
+        void loginOrRegister_googleClientFail() {
+            // given
+            when(googleClient.getGoogleAccountProfile(any()))
+                    .thenThrow(new RuntimeException("Google API error"));
+
+            // when & then
+            assertThatThrownBy(() -> googleAuthService.loginOrRegister("code"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Google API error");
+
+            verify(googleClient, times(1)).getGoogleAccountProfile(any());
+            verifyNoInteractions(userRepository, jwtUtil, refreshTokenRepository);
+        }
+
+        @Test
+        @DisplayName("JWT 생성 실패 시 로그인 실패")
+        void loginOrRegister_jwtGenerationFail() {
+            // given
+            when(googleClient.getGoogleAccountProfile(any()))
+                    .thenReturn(profile);
+
+            when(userRepository.findByEmail(profile.email()))
+                    .thenReturn(Optional.of(user));
+
+            when(jwtUtil.generateAccessToken(user.getId()))
+                    .thenThrow(new RuntimeException("JWT 생성 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> googleAuthService.loginOrRegister("code"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("JWT 생성 실패");
+
+            verify(jwtUtil, times(1)).generateAccessToken(user.getId());
+            verify(jwtUtil, never()).generateRefreshToken(any());
+            verifyNoInteractions(refreshTokenRepository);
+        }
+
+        @Test
+        @DisplayName("RefreshToken 저장 실패 시 로그인 실패")
+        void loginOrRegister_refreshTokenSaveFail() {
+            // given
+            when(googleClient.getGoogleAccountProfile(any()))
+                    .thenReturn(profile);
+
+            when(userRepository.findByEmail(profile.email()))
+                    .thenReturn(Optional.of(user));
+
+            when(jwtUtil.generateAccessToken(user.getId()))
+                    .thenReturn("access-token");
+
+            when(jwtUtil.generateRefreshToken(user.getId()))
+                    .thenReturn("refresh-token");
+
+            when(jwtUtil.getJti("refresh-token"))
+                    .thenReturn("jti");
+
+            when(jwtUtil.getRemainingExpiration("refresh-token"))
+                    .thenReturn(3600L);
+
+            doThrow(new RuntimeException("Redis 저장 실패"))
+                    .when(refreshTokenRepository)
+                    .save(any(), anyLong());
+
+            // when & then
+            assertThatThrownBy(() -> googleAuthService.loginOrRegister("code"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Redis 저장 실패");
+
+            verify(refreshTokenRepository, times(1))
+                    .save("jti", 3600L);
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    class logout {
+
+        @Mock
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            when(userDetails.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(1L);
+
+            when(jwtProperties.getHeader()).thenReturn("Authorization");
+            when(cookieConfig.getDomain()).thenReturn("localhost");
+            when(cookieConfig.isSecure()).thenReturn(false);
+            when(cookieConfig.getSameSite()).thenReturn("Lax");
+        }
+
+        @Test
+        @DisplayName("Refresh Token이 존재하면 화이트리스트에서 삭제한다")
+        void delete_refresh_token_success() {
+            // given
+            String refreshToken = "refresh-token";
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() -> CookieUtil.getRefreshTokenFromCookie(request))
+                        .thenReturn(refreshToken);
+
+                when(jwtUtil.getJti(refreshToken)).thenReturn("refresh-jti");
+
+                // when
+                googleAuthService.logout(userDetails, request, response);
+
+                // then
+                verify(refreshTokenRepository, times(1))
+                        .delete("refresh-jti");
+            }
+        }
+
+        @Test
+        @DisplayName("Refresh Token이 없으면 삭제를 시도하지 않는다")
+        void refresh_token_not_exists() {
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() -> CookieUtil.getRefreshTokenFromCookie(request))
+                        .thenReturn(null);
+
+                googleAuthService.logout(userDetails, request, response);
+
+                verifyNoInteractions(refreshTokenRepository);
+            }
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더가 있으면 블랙리스트에 등록한다")
+        void blacklist_access_token_success() {
+            // given
+            when(request.getHeader("Authorization"))
+                    .thenReturn("Bearer access-token");
+
+            when(jwtUtil.getJti("access-token"))
+                    .thenReturn("access-jti");
+
+            when(jwtUtil.getRemainingExpiration("access-token"))
+                    .thenReturn(3600L);
+
+            // when
+            googleAuthService.logout(userDetails, request, response);
+
+            // then
+            verify(blacklistTokenRepository, times(1))
+                    .save("access-jti", 3600L);
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더가 없으면 블랙리스트 등록하지 않는다")
+        void no_authorization_header() {
+            when(request.getHeader("Authorization")).thenReturn(null);
+
+            googleAuthService.logout(userDetails, request, response);
+
+            verifyNoInteractions(blacklistTokenRepository);
+        }
+
+        @Test
+        @DisplayName("Refresh Token 삭제 중 예외 발생해도 로그아웃은 계속 진행된다")
+        void refresh_token_exception_handled() {
+            String refreshToken = "refresh-token";
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() -> CookieUtil.getRefreshTokenFromCookie(request))
+                        .thenReturn(refreshToken);
+
+                when(jwtUtil.getJti(refreshToken))
+                        .thenThrow(new RuntimeException("JWT 파싱 실패"));
+
+                assertDoesNotThrow(() ->
+                        googleAuthService.logout(userDetails, request, response)
+                );
+            }
+        }
+
+        @Test
+        @DisplayName("Access Token 블랙리스트 등록 실패해도 예외를 던지지 않는다")
+        void access_token_exception_handled() {
+            when(request.getHeader("Authorization"))
+                    .thenReturn("Bearer access-token");
+
+            when(jwtUtil.getJti("access-token"))
+                    .thenThrow(new RuntimeException("JWT 파싱 실패"));
+
+            assertDoesNotThrow(() ->
+                    googleAuthService.logout(userDetails, request, response)
+            );
+        }
+
+        @Test
+        @DisplayName("로그아웃 시 항상 Refresh Token 쿠키를 삭제한다")
+        void delete_cookie_always() {
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                googleAuthService.logout(userDetails, request, response);
+
+                cookieUtil.verify(() ->
+                                CookieUtil.deleteCookie(
+                                        response,
+                                        "refreshToken",
+                                        "localhost",
+                                        false,
+                                        "Lax"
+                                ),
+                        times(1)
+                );
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("reissueToken")
+    class ReissueToken {
+
+        @BeforeEach
+        void setUp() {
+            user = User.builder()
+                    .id(1L)
+                    .email("test@test.com")
+                    .name("tester")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("정상적으로 Access / Refresh Token을 재발급한다")
+        void reissue_success() {
+            // given
+            String oldRefreshToken = "old-refresh-token";
+            String oldJti = "old-jti";
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+            String newJti = "new-jti";
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() ->
+                        CookieUtil.getRefreshTokenFromCookie(request)
+                ).thenReturn(oldRefreshToken);
+
+                when(jwtUtil.validateRefreshToken(oldRefreshToken))
+                        .thenReturn(1L);
+
+                when(jwtUtil.getJti(oldRefreshToken))
+                        .thenReturn(oldJti);
+
+                when(refreshTokenRepository.exists(oldJti))
+                        .thenReturn(true);
+
+                when(userRepository.findById(1L))
+                        .thenReturn(Optional.of(user));
+
+                when(jwtUtil.generateAccessToken(1L))
+                        .thenReturn(newAccessToken);
+
+                when(jwtUtil.generateRefreshToken(1L))
+                        .thenReturn(newRefreshToken);
+
+                when(jwtUtil.getJti(newRefreshToken))
+                        .thenReturn(newJti);
+
+                when(jwtUtil.getRemainingExpiration(newRefreshToken))
+                        .thenReturn(3600L);
+
+                ResponseEntity<ApiResponse<Void>> responseEntity =
+                        ResponseEntity.ok(ApiResponse.ok(null));
+
+                when(tokenResponseBuilder.buildTokenResponse(
+                        newAccessToken,
+                        newRefreshToken,
+                        response
+                )).thenReturn(responseEntity);
+
+                // when
+                ResponseEntity<ApiResponse<Void>> result =
+                        googleAuthService.reissueToken(request, response);
+
+                // then
+                assertThat(result).isNotNull();
+
+                verify(refreshTokenRepository).delete(oldJti);
+                verify(refreshTokenRepository).save(newJti, 3600L);
+            }
+        }
+    }
+}

--- a/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
+++ b/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
@@ -19,6 +19,8 @@ import org.project.domain.user.repository.BlacklistTokenRepository;
 import org.project.domain.user.repository.RefreshTokenRepository;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.config.security.CookieConfig;
+import org.project.global.exception.domainException.LoginException;
+import org.project.global.exception.errorcode.LoginErrorCode;
 import org.project.global.response.ApiResponse;
 import org.project.global.security.client.GoogleClient;
 import org.project.global.security.client.dto.GoogleAccountProfileResponse;
@@ -447,6 +449,23 @@ class GoogleAuthServiceTest {
 
                 verify(refreshTokenRepository).delete(oldJti);
                 verify(refreshTokenRepository).save(newJti, 3600L);
+            }
+        }
+
+        @Test
+        @DisplayName("Refresh Token이 없으면 예외 발생")
+        void refresh_token_not_found() {
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() ->
+                        CookieUtil.getRefreshTokenFromCookie(request)
+                ).thenReturn(null);
+
+                assertThatThrownBy(() ->
+                        googleAuthService.reissueToken(request, response)
+                )
+                        .isInstanceOf(LoginException.class)
+                        .hasMessageContaining(LoginErrorCode.REFRESH_TOKEN_NOT_FOUND.getMsg());
             }
         }
     }

--- a/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
+++ b/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
@@ -1,5 +1,6 @@
 package org.project.domain.user.service;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -527,6 +528,28 @@ class GoogleAuthServiceTest {
                 )
                         .isInstanceOf(UserException.class)
                         .hasMessageContaining(UserErrorCode.NOT_FOUND_USER.getMsg());
+            }
+        }
+
+        @Test
+        @DisplayName("JWT 검증 실패 시 INVALID_REFRESH_TOKEN")
+        void jwt_validation_failed() {
+            String refreshToken = "refresh-token";
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() ->
+                        CookieUtil.getRefreshTokenFromCookie(request)
+                ).thenReturn(refreshToken);
+
+                when(jwtUtil.validateRefreshToken(refreshToken))
+                        .thenThrow(new JwtException("invalid"));
+
+                assertThatThrownBy(() ->
+                        googleAuthService.reissueToken(request, response)
+                )
+                        .isInstanceOf(LoginException.class)
+                        .hasMessageContaining(LoginErrorCode.INVALID_REFRESH_TOKEN.getMsg());
             }
         }
     }

--- a/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
+++ b/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
@@ -468,5 +468,33 @@ class GoogleAuthServiceTest {
                         .hasMessageContaining(LoginErrorCode.REFRESH_TOKEN_NOT_FOUND.getMsg());
             }
         }
+
+        @Test
+        @DisplayName("화이트리스트에 없으면 INVALID_REFRESH_TOKEN")
+        void refresh_token_not_in_whitelist() {
+            String refreshToken = "refresh-token";
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() ->
+                        CookieUtil.getRefreshTokenFromCookie(request)
+                ).thenReturn(refreshToken);
+
+                when(jwtUtil.validateRefreshToken(refreshToken))
+                        .thenReturn(1L);
+
+                when(jwtUtil.getJti(refreshToken))
+                        .thenReturn("jti");
+
+                when(refreshTokenRepository.exists("jti"))
+                        .thenReturn(false);
+
+                assertThatThrownBy(() ->
+                        googleAuthService.reissueToken(request, response)
+                )
+                        .isInstanceOf(LoginException.class)
+                        .hasMessageContaining(LoginErrorCode.INVALID_REFRESH_TOKEN.getMsg());
+            }
+        }
     }
 }

--- a/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
+++ b/src/test/java/org/project/domain/user/service/GoogleAuthServiceTest.java
@@ -20,7 +20,9 @@ import org.project.domain.user.repository.RefreshTokenRepository;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.config.security.CookieConfig;
 import org.project.global.exception.domainException.LoginException;
+import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.LoginErrorCode;
+import org.project.global.exception.errorcode.UserErrorCode;
 import org.project.global.response.ApiResponse;
 import org.project.global.security.client.GoogleClient;
 import org.project.global.security.client.dto.GoogleAccountProfileResponse;
@@ -494,6 +496,37 @@ class GoogleAuthServiceTest {
                 )
                         .isInstanceOf(LoginException.class)
                         .hasMessageContaining(LoginErrorCode.INVALID_REFRESH_TOKEN.getMsg());
+            }
+        }
+
+        @Test
+        @DisplayName("User가 존재하지 않으면 예외 발생")
+        void user_not_found() {
+            String refreshToken = "refresh-token";
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+
+                cookieUtil.when(() ->
+                        CookieUtil.getRefreshTokenFromCookie(request)
+                ).thenReturn(refreshToken);
+
+                when(jwtUtil.validateRefreshToken(refreshToken))
+                        .thenReturn(1L);
+
+                when(jwtUtil.getJti(refreshToken))
+                        .thenReturn("jti");
+
+                when(refreshTokenRepository.exists("jti"))
+                        .thenReturn(true);
+
+                when(userRepository.findById(1L))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() ->
+                        googleAuthService.reissueToken(request, response)
+                )
+                        .isInstanceOf(UserException.class)
+                        .hasMessageContaining(UserErrorCode.NOT_FOUND_USER.getMsg());
             }
         }
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #36 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 메모 생성 서비스 레이어 테스트코드를 작성했습니다.
- 메모 전체 조회 서비스 레이어 테스트코드를 작성했습니다.
- 구글 로그인 서비스 레이어 테스트코드를 작성했습니다.
- 로그아웃 서비스 레이어 테스트코드를 작성했습니다.
- 토큰 재발급 서비스 레이어 테스트코드를 작성했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 메모 서비스 및 인증 서비스에 대한 포괄적인 단위 테스트 추가
  * 애플리케이션 컨텍스트 로드 테스트 추가

* **Chores**
  * 테스트 환경 설정 업데이트 (인메모리 데이터베이스, OAuth2, JWT, Redis, AWS S3 설정 추가)
  * 테스트 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->