### PR TITLE
[Feat] 유저 정보조회 API 구현

### DIFF
--- a/src/main/java/org/project/domain/user/controller/UserController.java
+++ b/src/main/java/org/project/domain/user/controller/UserController.java
@@ -1,0 +1,42 @@
+package org.project.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.project.domain.user.dto.CustomUserDetails;
+import org.project.domain.user.dto.response.UserInfoResponse;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.service.UserService;
+import org.project.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+@Tag(name = "유저 관련 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    @Operation(
+            summary = "유저 정보 조회",
+            description = "유저 정보를 조회하여, 이름, 이메일, 프로필이미지를 올립니다."
+    )
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        UserInfoResponse response = userService.getUserInfo(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(response)
+        );
+    }
+}

--- a/src/main/java/org/project/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/project/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,20 @@
+package org.project.domain.user.dto.response;
+
+import org.project.domain.user.entity.User;
+
+public record UserInfoResponse(
+        Long userId,
+        String name,
+        String email,
+        String profileImageUrl
+) {
+
+    public static UserInfoResponse of(User user) {
+        return new UserInfoResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/org/project/domain/user/service/UserService.java
+++ b/src/main/java/org/project/domain/user/service/UserService.java
@@ -1,4 +1,8 @@
 package org.project.domain.user.service;
 
+import org.project.domain.user.dto.response.UserInfoResponse;
+
 public interface UserService {
+
+    UserInfoResponse getUserInfo(Long userId);
 }

--- a/src/main/java/org/project/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/project/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,11 @@
 package org.project.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.domain.user.dto.response.UserInfoResponse;
+import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
+import org.project.global.exception.domainException.UserException;
+import org.project.global.exception.errorcode.UserErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,4 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+
+    @Override
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        return UserInfoResponse.of(user);
+    }
 }

--- a/src/test/java/org/project/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/org/project/domain/user/service/UserServiceImplTest.java
@@ -1,0 +1,72 @@
+package org.project.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.project.domain.user.dto.response.UserInfoResponse;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.exception.domainException.UserException;
+import org.project.global.exception.errorcode.UserErrorCode;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    UserServiceImpl userService;
+
+    @Test
+    @DisplayName("유저 정보 조회 성공")
+    void getUserInfo_success() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .id(userId)
+                .email("test@test.com")
+                .name("테스트유저")
+                .profileImageUrl("https://image.url")
+                .providerName("GOOGLE")
+                .build();
+
+        given(userRepository.findById(userId))
+                .willReturn(Optional.of(user));
+
+        // when
+        UserInfoResponse response = userService.getUserInfo(userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.email()).isEqualTo("test@test.com");
+        assertThat(response.name()).isEqualTo("테스트유저");
+        assertThat(response.profileImageUrl()).isEqualTo("https://image.url");
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않으면 예외 발생")
+    void getUserInfo_userNotFound() {
+        // given
+        Long userId = 99L;
+
+        given(userRepository.findById(userId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserInfo(userId))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_FOUND_USER.getMsg());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #61 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 유저 정보조회하여, 이름, 이메일, 프로필이미지를 응답 받습니다.
- 유저 정보조회 API 추가에 따라 테스트 코드를 작성했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인증된 사용자가 자신의 프로필 정보를 조회할 수 있는 새로운 API 엔드포인트 추가
* 조회 가능한 정보: 사용자 ID, 이름, 이메일, 프로필 이미지

## 테스트
* 프로필 정보 조회 기능에 대한 단위 테스트 추가 (정상 조회 및 오류 처리)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->