### PR TITLE
feat: 구조화 뷰를 위한 전체 메모 조회 및 마크다운 문법 제거 유틸 추가

### DIFF
--- a/src/main/java/org/project/domain/ai/controller/MemoAiController.java
+++ b/src/main/java/org/project/domain/ai/controller/MemoAiController.java
@@ -33,7 +33,7 @@ public class MemoAiController {
     private final AiEvaluationService aiEvaluationService;
 
     @Operation(
-            summary = "메모 기반 AI 응답 생성",
+            summary = "AI 메모 응답 생성",
             description = """
                     선택한 메모들을 기반으로 RAG를 수행하여
                     AI 응답을 생성합니다.

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -164,6 +164,7 @@ public class MemoController {
     }
 
     @GetMapping("/structure")
+    @Operation(summary = "구조화뷰 메모 조회", description = "구조화뷰를 위한 전체 메모를 조회합니다.")
     public ResponseEntity<ApiResponse<MemoStructureListResponse>> getStructureMemo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ){

--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -12,6 +12,7 @@ import org.project.domain.memo.dto.response.MemoDetailResponse;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
+import org.project.domain.memo.dto.response.MemoStructureListResponse;
 import org.project.domain.memo.service.MemoService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.global.annotation.BusinessExceptionDescription;
@@ -79,9 +80,9 @@ public class MemoController {
     }
 
     @Operation(
-            summary = "AI 메모 작성",
+            summary = "AI가 만든 메모 저장",
             description = """
-                AI 응답 결과를 기반으로 메모를 작성합니다.
+                AI 응답 결과를 기반으로 메모를 등록요청을 하는 API입니다.
                 제목과 본문을 분리해서 전달해야 합니다.
                 """
     )
@@ -156,6 +157,19 @@ public class MemoController {
         Long userId = userDetails.getUserId();
 
         MemoDetailResponse response = memoService.getOneMemoDetail(userId, memoId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok(response));
+
+    }
+
+    @GetMapping("/structure")
+    public ResponseEntity<ApiResponse<MemoStructureListResponse>> getStructureMemo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        Long userId = userDetails.getUserId();
+
+        MemoStructureListResponse response = memoService.getStructureMemo(userId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.ok(response));

--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -3,6 +3,7 @@ package org.project.domain.memo.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.label.entity.Label;
 import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoLabel;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -26,8 +27,8 @@ public record MemoDetailResponse(
         @Schema(description = "첨부 파일 정보 목록")
         List<FileInfo> files,
 
-        @Schema(description = "메모에 딸린 라벨들", example = "[\"SOPT\", \"졸업프로젝트\", \"교양\", \"레퍼런스\"]")
-        List<String> labelList,
+        @Schema(description = "메모에 딸린 라벨들")
+        List<MemoListDashboardResponse.LabelResponse> labelList,
 
         @Schema(description = "메모 생성 시각", example = "2026-01-13T10:30:00")
         LocalDateTime createdAt,
@@ -90,8 +91,9 @@ public record MemoDetailResponse(
                 memo.getContent(),
                 images,
                 files,
-                memo.getLabels().stream()
-                        .map(Label::getName)
+                memo.getMemoLabels().stream()
+                        .map(MemoLabel::getLabel)
+                        .map(MemoListDashboardResponse.LabelResponse::from)
                         .toList(),
                 memo.getCreatedAt(),
                 memo.getIsAiGenerated(),

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -34,7 +34,7 @@ public record MemoListDashboardResponse(
             Boolean isAiGenerated,
             LocalDateTime createdAt,
 
-            List<String> labelList
+            List<LabelResponse> labelList
     ) {
 
         /**
@@ -57,9 +57,26 @@ public record MemoListDashboardResponse(
                     memo.getIsPinned(),
                     memo.getIsAiGenerated(),
                     memo.getCreatedAt(),
-                    memo.getLabels().stream()
-                            .map(Label::getName)
+                    memo.getMemoLabels().stream()
+                            .map(MemoLabel::getLabel)
+                            .map(LabelResponse::from)
                             .toList()
+            );
+        }
+    }
+
+    /**
+     * 라벨 응답
+     */
+    public record LabelResponse(
+            Long labelId,
+            String name
+    ) {
+
+        public static LabelResponse from(Label label) {
+            return new LabelResponse(
+                    label.getId(),
+                    label.getName()
             );
         }
     }

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -43,6 +43,7 @@ public record MemoListDashboardResponse(
          */
         public static MemoDashboardResponse of(
                 Memo memo,
+                String content,
                 String representativeImageUrl,
                 int imageCount,
                 int fileCount
@@ -50,7 +51,7 @@ public record MemoListDashboardResponse(
             return new MemoDashboardResponse(
                     memo.getId(),
                     memo.getTitle(),
-                    memo.getContent(),
+                    content,
                     representativeImageUrl,
                     imageCount,
                     fileCount,
@@ -62,6 +63,15 @@ public record MemoListDashboardResponse(
                             .map(LabelResponse::from)
                             .toList()
             );
+        }
+
+        public static MemoDashboardResponse of(
+                Memo memo,
+                String representativeImageUrl,
+                int imageCount,
+                int fileCount
+        ) {
+            return of(memo, memo.getContent(), representativeImageUrl, imageCount, fileCount);
         }
     }
 

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
@@ -1,0 +1,11 @@
+package org.project.domain.memo.dto.response;
+
+import java.util.List;
+
+public record MemoStructureListResponse(
+        List<MemoStructureResponse> memos
+) {
+    public static MemoStructureListResponse from(List<MemoStructureResponse> memos) {
+        return new MemoStructureListResponse(memos);
+    }
+}

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
@@ -1,8 +1,11 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MemoStructureListResponse(
+        @Schema(description = "구조화뷰 메모 목록")
         List<MemoStructureResponse> memos
 ) {
     public static MemoStructureListResponse from(List<MemoStructureResponse> memos) {

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
@@ -1,0 +1,33 @@
+package org.project.domain.memo.dto.response;
+
+import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoLabel;
+
+import java.util.List;
+
+public record MemoStructureResponse(
+        Long memoId,
+
+        String title,
+
+        String content,
+
+        List<MemoListDashboardResponse.LabelResponse> labelList
+) {
+
+    public static MemoStructureResponse from(
+            Memo memo
+    ) {
+        return new MemoStructureResponse(
+                memo.getId(),
+                memo.getTitle(),
+                memo.getContent(),
+                memo.getMemoLabels().stream()
+                        .map(MemoLabel::getLabel)
+                        .map(MemoListDashboardResponse.LabelResponse::from)
+                        .toList()
+        );
+    }
+}
+
+

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
@@ -3,15 +3,21 @@ package org.project.domain.memo.dto.response;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoLabel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MemoStructureResponse(
+        @Schema(description = "메모 ID", example = "1")
         Long memoId,
 
+        @Schema(description = "메모 제목", example = "집에 빨리 가는 법")
         String title,
 
+        @Schema(description = "메모 내용", example = "발박수 치며 날아 간다.")
         String content,
 
+        @Schema(description = "메모에 딸린 라벨 목록")
         List<MemoListDashboardResponse.LabelResponse> labelList
 ) {
 
@@ -36,4 +42,3 @@ public record MemoStructureResponse(
         );
     }
 }
-

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
@@ -18,10 +18,17 @@ public record MemoStructureResponse(
     public static MemoStructureResponse from(
             Memo memo
     ) {
+        return from(memo, memo.getContent());
+    }
+
+    public static MemoStructureResponse from(
+            Memo memo,
+            String content
+    ) {
         return new MemoStructureResponse(
                 memo.getId(),
                 memo.getTitle(),
-                memo.getContent(),
+                content,
                 memo.getMemoLabels().stream()
                         .map(MemoLabel::getLabel)
                         .map(MemoListDashboardResponse.LabelResponse::from)
@@ -29,5 +36,4 @@ public record MemoStructureResponse(
         );
     }
 }
-
 

--- a/src/main/java/org/project/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepository.java
@@ -28,4 +28,15 @@ public interface MemoRepository extends JpaRepository<Memo,Long>, MemoRepository
             @Param("userId") Long userId,
             @Param("memoIds") List<Long> memoIds
     );
+
+    @Query("""
+            SELECT DISTINCT m
+            FROM Memo m
+            LEFT JOIN FETCH m.memoLabels ml
+            LEFT JOIN FETCH ml.label
+            WHERE m.user.id = :userId
+              AND m.isDeleted = false
+            ORDER BY m.createdAt DESC, m.id DESC
+            """)
+    List<Memo> findAllByUserIdWithLabelsAndNotDeleted(@Param("userId") Long userId);
 }

--- a/src/main/java/org/project/domain/memo/service/MemoService.java
+++ b/src/main/java/org/project/domain/memo/service/MemoService.java
@@ -3,10 +3,7 @@ package org.project.domain.memo.service;
 import org.project.domain.memo.dto.request.MemoCreateRequest;
 import org.project.domain.memo.dto.request.MemoAiCreateRequest;
 import org.project.domain.memo.dto.request.MemoPresignedUrlRequest;
-import org.project.domain.memo.dto.response.MemoDetailResponse;
-import org.project.domain.memo.dto.response.MemoListDashboardResponse;
-import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
-import org.project.domain.memo.dto.response.MemoResponse;
+import org.project.domain.memo.dto.response.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,6 +28,8 @@ public interface MemoService {
     );
 
     MemoDetailResponse getOneMemoDetail(Long userId, Long memoId);
+
+    MemoStructureListResponse getStructureMemo(Long userId);
 
     void deleteMemo(Long userId, Long memoId);
 }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -6,10 +6,7 @@ import org.project.domain.label.repository.LabelRepository;
 import org.project.domain.memo.dto.request.MemoAiCreateRequest;
 import org.project.domain.memo.dto.request.MemoCreateRequest;
 import org.project.domain.memo.dto.request.MemoPresignedUrlRequest;
-import org.project.domain.memo.dto.response.MemoDetailResponse;
-import org.project.domain.memo.dto.response.MemoListDashboardResponse;
-import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
-import org.project.domain.memo.dto.response.MemoResponse;
+import org.project.domain.memo.dto.response.*;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoFile;
 import org.project.domain.memo.entity.MemoImage;
@@ -243,6 +240,18 @@ public class MemoServiceImpl implements MemoService {
         List<MemoDetailResponse.FileInfo> files = mapToFileInfos(memo.getMemoFiles());
 
         return MemoDetailResponse.from(memo, images, files);
+    }
+
+    @Override
+    public MemoStructureListResponse getStructureMemo(Long userId){
+        // 메모 + 라벨 한번에 조회
+        List<Memo> memos = memoRepository.findAllByUserIdWithLabelsAndNotDeleted(userId);
+
+        List<MemoStructureResponse> responses = memos.stream()
+                .map(MemoStructureResponse::from)
+                .toList();
+
+        return MemoStructureListResponse.from(responses);
     }
 
     @Override

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -25,6 +25,7 @@ import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.MemoErrorCode;
 import org.project.global.exception.errorcode.UserErrorCode;
 import org.project.global.util.FileSizeUtil;
+import org.project.global.util.MarkdownUtil;
 import org.project.global.util.S3KeyUtil;
 import org.project.global.util.S3Util;
 import org.springframework.context.ApplicationEventPublisher;
@@ -248,7 +249,7 @@ public class MemoServiceImpl implements MemoService {
         List<Memo> memos = memoRepository.findAllByUserIdWithLabelsAndNotDeleted(userId);
 
         List<MemoStructureResponse> responses = memos.stream()
-                .map(MemoStructureResponse::from)
+                .map(memo -> MemoStructureResponse.from(memo, MarkdownUtil.strip(memo.getContent())))
                 .toList();
 
         return MemoStructureListResponse.from(responses);
@@ -448,6 +449,7 @@ public class MemoServiceImpl implements MemoService {
 
         return MemoListDashboardResponse.MemoDashboardResponse.of(
                 memo,
+                MarkdownUtil.strip(memo.getContent()),
                 representativeImageUrl,
                 memoImages.size(),
                 memoFiles.size()

--- a/src/main/java/org/project/global/util/MarkdownUtil.java
+++ b/src/main/java/org/project/global/util/MarkdownUtil.java
@@ -1,0 +1,52 @@
+package org.project.global.util;
+
+import java.util.regex.Pattern;
+
+public final class MarkdownUtil {
+    private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```");
+    private static final Pattern INLINE_CODE = Pattern.compile("`[^`]*`");
+    private static final Pattern IMAGES = Pattern.compile("!\\[(.*?)]\\((.*?)\\)");
+    private static final Pattern LINKS = Pattern.compile("\\[(.*?)]\\((.*?)\\)");
+    // 헤더 기호 제거
+    private static final Pattern HEADING = Pattern.compile("(?m)^\\s{0,3}#{1,6}\\s+");
+    private static final Pattern BLOCKQUOTE = Pattern.compile("(?m)^\\s*>\\s?");
+    // 리스트 기호 제거
+    private static final Pattern UL_LIST = Pattern.compile("(?m)^\\s*[-*+]\\s+");
+    // 같은 번호 리스트 기호 제거
+    private static final Pattern OL_LIST = Pattern.compile("(?m)^\\s*\\d+\\.\\s+");
+    // 구분선 제거
+    private static final Pattern HORIZONTAL_RULE = Pattern.compile("(?m)^\\s*([-*_]\\s*){3,}$");
+    private static final Pattern BOLD = Pattern.compile("(\\*\\*|__)(.*?)\\1");
+    private static final Pattern ITALIC = Pattern.compile("(\\*|_)(.*?)\\1");
+    private static final Pattern STRIKETHROUGH = Pattern.compile("~~(.*?)~~");
+    private static final Pattern TRAILING_SPACES = Pattern.compile("(?m)[ \\t]+$");
+    private static final Pattern MULTI_SPACES = Pattern.compile("[ \\t]{2,}");
+    private static final Pattern MULTI_NEWLINES = Pattern.compile("\\n{3,}");
+
+    private MarkdownUtil() {}
+
+    public static String strip(String input) {
+        if (input == null || input.isBlank()) {
+            return input;
+        }
+
+        String result = input;
+        result = FENCED_CODE.matcher(result).replaceAll("");
+        result = INLINE_CODE.matcher(result).replaceAll("");
+        result = IMAGES.matcher(result).replaceAll("$1");
+        result = LINKS.matcher(result).replaceAll("$1");
+        result = HEADING.matcher(result).replaceAll("");
+        result = BLOCKQUOTE.matcher(result).replaceAll("");
+        result = UL_LIST.matcher(result).replaceAll("");
+        result = OL_LIST.matcher(result).replaceAll("");
+        result = HORIZONTAL_RULE.matcher(result).replaceAll("");
+        result = STRIKETHROUGH.matcher(result).replaceAll("$1");
+        result = BOLD.matcher(result).replaceAll("$2");
+        result = ITALIC.matcher(result).replaceAll("$2");
+        result = TRAILING_SPACES.matcher(result).replaceAll("");
+        result = MULTI_SPACES.matcher(result).replaceAll(" ");
+        result = MULTI_NEWLINES.matcher(result).replaceAll("\n\n");
+
+        return result.trim();
+    }
+}

--- a/src/main/java/org/project/global/util/MarkdownUtil.java
+++ b/src/main/java/org/project/global/util/MarkdownUtil.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 
 public final class MarkdownUtil {
     private static final Pattern FENCED_CODE = Pattern.compile("(?s)```.*?```");
-    private static final Pattern INLINE_CODE = Pattern.compile("`[^`]*`");
+    private static final Pattern INLINE_CODE = Pattern.compile("`([^`]*)`");
     private static final Pattern IMAGES = Pattern.compile("!\\[(.*?)]\\((.*?)\\)");
     private static final Pattern LINKS = Pattern.compile("\\[(.*?)]\\((.*?)\\)");
     // 헤더 기호 제거
@@ -32,7 +32,7 @@ public final class MarkdownUtil {
 
         String result = input;
         result = FENCED_CODE.matcher(result).replaceAll("");
-        result = INLINE_CODE.matcher(result).replaceAll("");
+        result = INLINE_CODE.matcher(result).replaceAll("$1");
         result = IMAGES.matcher(result).replaceAll("$1");
         result = LINKS.matcher(result).replaceAll("$1");
         result = HEADING.matcher(result).replaceAll("");

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -803,7 +803,10 @@ class MemoControllerTest {
                             false,  // isPinned
                             false,  // isAiGenerated
                             LocalDateTime.now(),
-                            List.of("SOPT", "교양")
+                            List.of(
+                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT"),
+                                    new MemoListDashboardResponse.LabelResponse(2L, "교양")
+                            )
                     );
 
             MemoListDashboardResponse.MemoDashboardResponse memo2 =
@@ -871,7 +874,9 @@ class MemoControllerTest {
                             false,
                             false,
                             LocalDateTime.now(),
-                            List.of("SOPT")
+                            List.of(
+                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT")
+                            )
                     );
 
             MemoListDashboardResponse expectedResponse =

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -897,7 +897,8 @@ class MemoControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.memos.length()").value(1))
-                    .andExpect(jsonPath("$.data.memos[0].labelList[0]").value("SOPT"));
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].labelId").value(1L))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].name").value("SOPT"));
 
             verify(memoService, times(1))
                     .getMemosWithMedia(eq(userId), eq(labelIds), eq(null), eq(null), eq(20));
@@ -1041,7 +1042,11 @@ class MemoControllerTest {
                     "7차 세미나 내용은 매우 중요합니다.",
                     List.of(image1, image2),
                     List.of(file),
-                    List.of("SOPT", "교양", "레퍼런스"),
+                    List.of(
+                            new MemoListDashboardResponse.LabelResponse(1L, "SOPT"),
+                            new MemoListDashboardResponse.LabelResponse(2L, "교양"),
+                            new MemoListDashboardResponse.LabelResponse(3L, "레퍼런스")
+                    ),
                     LocalDateTime.of(2026, 1, 16, 10, 30),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
@@ -1070,7 +1075,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.files[0].fileName").value("SOPT_7th_seminar.pdf"))
                     .andExpect(jsonPath("$.data.labelList").isArray())
                     .andExpect(jsonPath("$.data.labelList.length()").value(3))
-                    .andExpect(jsonPath("$.data.labelList[0]").value("SOPT"))
+                    .andExpect(jsonPath("$.data.labelList[0].labelId").value(1L))
+                    .andExpect(jsonPath("$.data.labelList[0].name").value("SOPT"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.sourceList").isArray())
                     .andExpect(jsonPath("$.data.sourceList.length()").value(0));
@@ -1093,7 +1099,7 @@ class MemoControllerTest {
                     "사용자가 직접 작성한 메모입니다.",
                     List.of(),
                     List.of(),
-                    List.of("개인"),
+                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "개인")),
                     LocalDateTime.of(2026, 1, 16, 12, 0),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
@@ -1129,7 +1135,7 @@ class MemoControllerTest {
                     "이미지나 파일 없이 텍스트만 있습니다.",
                     List.of(),  // 이미지 없음
                     List.of(),  // 파일 없음
-                    List.of("메모"),
+                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "메모")),
                     LocalDateTime.of(2026, 1, 16, 13, 0),
                     false,
                     List.of()


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #66 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 구조화뷰 / 대시보드 GET 시에 마크다운 문법을 제거하며 응답을 주도록 변경했습니다.
- 마크다운 문법을 제거하기 위해 MarkDownUtil 파일을 추가했습니다.
- 상세모달창은 마크다운 문법 그대로 응답을 주도록 했습니다.
- 라벨 응답을 Id, name 리스트로 통일해서 보내달라는 요청이 있어 다시 변경했습니다.
## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메모 구조화 조회용 신규 API 엔드포인트 추가

* **개선사항**
  * 메모 응답의 라벨 정보 확장(라벨 ID 및 이름 포함)
  * 메모 콘텐츠 표시 최적화(마크다운 요소 제거로 가독성 향상)
  * 대시보드/상세 응답의 콘텐츠 처리 방식 개선

* **기타**
  * AI 메모 관련 설명 문구 소폭 변경 (사용자 노출 문구 업데이트)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->