### PR TITLE
[FIX] AI로 생성된 메모 상세조회시 소스메모 제목 리스트 응답

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -36,8 +36,11 @@ public record MemoDetailResponse(
         @Schema(description = "AI 생성 여부", example = "false")
         Boolean isAiGenerated,
 
-        @Schema(description = "AI 생성 시 참고한 메모 ID 목록", example = "[1, 2, 3]")
-        List<Long> sourceList
+        @Schema(
+                description = "AI 생성 시 참고한 메모 제목 목록",
+                example = "[\"UX 리서치 정리\", \"시험 대비 요약\"]"
+        )
+        List<String> sourceMemoTitleList
 ) {
 
     @Schema(description = "이미지 정보")
@@ -82,7 +85,8 @@ public record MemoDetailResponse(
     public static MemoDetailResponse from(
             Memo memo,
             List<ImageInfo> images,
-            List<FileInfo> files
+            List<FileInfo> files,
+            List<Memo> sourceMemos
     ) {
 
         return new MemoDetailResponse(
@@ -97,34 +101,19 @@ public record MemoDetailResponse(
                         .toList(),
                 memo.getCreatedAt(),
                 memo.getIsAiGenerated(),
-                memo.getIsAiGenerated() && memo.getSource() != null
-                        ? parseSourceIds(memo.getSource())
+                memo.getIsAiGenerated()
+                        ? extractSourceTitles(sourceMemos)
                         : Collections.emptyList()
         );
     }
 
-    // 소스메모 id 파싱 메서드
-    private static List<Long> parseSourceIds(String source) {
-        if (source == null || source.isEmpty()) {
+    private static List<String> extractSourceTitles(List<Memo> sourceMemos) {
+        if (sourceMemos == null || sourceMemos.isEmpty()) {
             return Collections.emptyList();
         }
 
-        try {
-            String normalized = source.trim();
-            if (normalized.startsWith("[") && normalized.endsWith("]")) {
-                normalized = normalized.substring(1, normalized.length() - 1);
-            }
-
-            if (normalized.isBlank()) {
-                return Collections.emptyList();
-            }
-
-            return Arrays.stream(normalized.split(","))
-                    .map(String::trim)
-                    .map(Long::parseLong)
-                    .toList();
-        } catch (NumberFormatException e) {
-            return Collections.emptyList();
-        }
+        return sourceMemos.stream()
+                .map(Memo::getTitle)
+                .toList();
     }
 }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -34,10 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -239,7 +236,22 @@ public class MemoServiceImpl implements MemoService {
         List<MemoDetailResponse.ImageInfo> images = mapToImageInfos(memo.getMemoImages());
         List<MemoDetailResponse.FileInfo> files = mapToFileInfos(memo.getMemoFiles());
 
-        return MemoDetailResponse.from(memo, images, files);
+        List<Memo> sourceMemos = Collections.emptyList();
+
+        if (Boolean.TRUE.equals(memo.getIsAiGenerated())
+                && memo.getSource() != null
+                && !memo.getSource().isBlank()) {
+
+            List<Long> sourceIds = parseSourceIds(memo.getSource());
+            sourceMemos = memoRepository.findAllById(sourceIds);
+        }
+
+        return MemoDetailResponse.from(
+                memo,
+                images,
+                files,
+                sourceMemos
+        );
     }
 
     @Override
@@ -519,4 +531,27 @@ public class MemoServiceImpl implements MemoService {
         }
     }
 
+    private List<Long> parseSourceIds(String source) {
+        if (source == null || source.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        String normalized = source.trim();
+        if (normalized.startsWith("[") && normalized.endsWith("]")) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+
+        if (normalized.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return Arrays.stream(normalized.split(","))
+                    .map(String::trim)
+                    .map(Long::parseLong)
+                    .toList();
+        } catch (NumberFormatException e) {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -1078,8 +1078,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.labelList[0].labelId").value(1L))
                     .andExpect(jsonPath("$.data.labelList[0].name").value("SOPT"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
-                    .andExpect(jsonPath("$.data.sourceList").isArray())
-                    .andExpect(jsonPath("$.data.sourceList.length()").value(0));
+                    .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
+                    .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
 
             verify(memoService, times(1))
                     .getOneMemoDetail(eq(userId), eq(memoId));
@@ -1114,8 +1114,8 @@ class MemoControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
-                    .andExpect(jsonPath("$.data.sourceList").isArray())
-                    .andExpect(jsonPath("$.data.sourceList.length()").value(0));
+                    .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
+                    .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
 
             verify(memoService, times(1))
                     .getOneMemoDetail(eq(userId), eq(memoId));


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #85 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- AI로 생성된 메모 상세조회시 소스메모id가 응답되던 것을 제목 리스트가 응답되도록 수정했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * AI로 생성된 메모의 출처가 참조 ID 대신 소스 메모의 제목으로 표시되어 어떤 메모를 기반으로 생성되었는지 더 명확해졌습니다.
* **테스트**
  * 메모 상세 응답의 출처 필드명이 변경된 것에 맞춰 관련 단위 테스트의 검증이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->