### PR TITLE
fix: AI 채팅 실패시 재시도 로직 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,10 @@ dependencies {
 
     // test h2
     testImplementation 'com.h2database:h2'
+
+    // retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
 
 def querydslDir = "src/main/generated/querydsl"

--- a/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
+++ b/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
@@ -1,18 +1,29 @@
 package org.project.domain.ai.rag.G.generate;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
+import org.project.global.exception.domainException.AiException;
+import org.project.global.exception.errorcode.AiErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DefaultRagGenerator implements RagGenerator {
 
     private final ChatClient chatClient;
 
+    @Retryable(
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     @Override
     public String generate(RagPrompt prompt) {
 
@@ -36,7 +47,17 @@ public class DefaultRagGenerator implements RagGenerator {
                 .content();
     }
 
+    @Recover
+    public String recover(Exception e, RagPrompt prompt) {
+        log.error("AI 생성 최종 실패 after 3 attempts: {}", e.getMessage(), e);
+        throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
+    }
+
     @Override
+    @Retryable(
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public String generateForPlan(RagPrompt prompt, String model, Double temperature) {
 
         return chatClient
@@ -62,5 +83,11 @@ public class DefaultRagGenerator implements RagGenerator {
                 ))
                 .call()
                 .content();
+    }
+
+    @Recover
+    public String recoverForPlan(Exception e, RagPrompt prompt, String model, Double temperature) {
+        log.error("Plan AI 생성 최종 실패 after 3 attempts: {}", e.getMessage(), e);
+        throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
     }
 }

--- a/src/main/java/org/project/global/config/retry/RetryConfig.java
+++ b/src/main/java/org/project/global/config/retry/RetryConfig.java
@@ -1,0 +1,10 @@
+package org.project.global.config.retry;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/org/project/global/exception/errorcode/AiErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/AiErrorCode.java
@@ -10,7 +10,8 @@ public enum AiErrorCode implements ErrorCode {
     UNSUPPORTED_TYPE(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 타입입니다."),
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "선택한 메모를 찾을 수 없습니다."),
     EMPTY_MEMO_IDS(HttpStatus.BAD_REQUEST, 400, "참조할 메모가 선택되지 않았습니다."),
-    CONVERSATION_CONTEXT_NOT_SET(HttpStatus.BAD_REQUEST, 400, "conversation context is not set (userId / chatRoomId)");
+    CONVERSATION_CONTEXT_NOT_SET(HttpStatus.BAD_REQUEST, 400, "conversation context is not set (userId / chatRoomId)"),
+    AI_GENERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #91 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Retry 의존성 추가 후 어노테이션으로 retry구현 후 recover로 폴백 로직 구현
- 자세한 retry는 노션에 정리해두었습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * AI 생성 작업의 안정성 향상을 위해 자동 재시도 메커니즘 추가
  * 일시적 실패 시 최대 3회까지 자동으로 재시도
  * AI 서비스 불가 상태에 대한 사용자 친화적 오류 메시지 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->