### PR TITLE
[Chore] Memo의 신규 생성 여부 추가

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -35,6 +35,7 @@ public record MemoListDashboardResponse(
 
             Boolean isPinned,
             Boolean isAiGenerated,
+            Boolean isNew,
             LocalDateTime createdAt,
 
             List<LabelResponse> labelList
@@ -60,6 +61,7 @@ public record MemoListDashboardResponse(
                     fileCount,
                     memo.getIsPinned(),
                     memo.getIsAiGenerated(),
+                    memo.getIsNew(),
                     memo.getCreatedAt(),
                     memo.getMemoLabels().stream()
                             .map(MemoLabel::getLabel)

--- a/src/main/java/org/project/domain/memo/entity/Memo.java
+++ b/src/main/java/org/project/domain/memo/entity/Memo.java
@@ -126,5 +126,4 @@ public class Memo extends BaseEntity {
     public void markAsRead() {
         this.isNew = false;
     }
-
 }

--- a/src/main/java/org/project/domain/memo/entity/Memo.java
+++ b/src/main/java/org/project/domain/memo/entity/Memo.java
@@ -123,30 +123,8 @@ public class Memo extends BaseEntity {
         this.isDeleted = true;
     }
 
-//    // 이미지 추가
-//    public void addImage(String imageS3Key, Long imageBytes, String imageExtension, Integer imagePriority) {
-//        MemoImage memoImage = MemoImage.builder()
-//                .memo(this)
-//                .imageS3Key(imageS3Key)
-//                .imageBytes(imageBytes)
-//                .imageExtension(imageExtension)
-//                .imagePriority(imagePriority)
-//                .build();
-//
-//        this.memoImages.add(memoImage);
-//    }
-
-//    // 파일 추가
-//    public void addFile(String fileS3Key, Long fileBytes, String fileExtension, Integer filePriority) {
-//        MemoFile memoFile = MemoFile.builder()
-//                .memo(this)
-//                .fileS3Key(fileS3Key)
-//                .fileBytes(fileBytes)
-//                .fileExtension(fileExtension)
-//                .filePriority(filePriority)
-//                .build();
-//
-//        this.memoFiles.add(memoFile);
-//    }
+    public void markAsRead() {
+        this.isNew = false;
+    }
 
 }

--- a/src/main/java/org/project/domain/memo/entity/Memo.java
+++ b/src/main/java/org/project/domain/memo/entity/Memo.java
@@ -36,6 +36,10 @@ public class Memo extends BaseEntity {
     @Builder.Default
     private Boolean isAiGenerated = false;
 
+    @Column(name = "is_new", nullable = false)
+    @Builder.Default
+    private Boolean isNew = true;
+
     @Column(name = "source")
     private String source;
 

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -233,6 +233,7 @@ public class MemoServiceImpl implements MemoService {
     }
 
     @Override
+    @Transactional
     public MemoDetailResponse getOneMemoDetail(Long userId, Long memoId) {
 
         Memo memo = getMemoOrThrow(memoId);

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -254,6 +254,8 @@ public class MemoServiceImpl implements MemoService {
             sourceMemos = memoRepository.findAllById(sourceIds);
         }
 
+        memo.markAsRead();
+
         return MemoDetailResponse.from(
                 memo,
                 images,

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -802,6 +802,7 @@ class MemoControllerTest {
                             1,  // 파일 개수
                             false,  // isPinned
                             false,  // isAiGenerated
+                            true,
                             LocalDateTime.now(),
                             List.of(
                                     new MemoListDashboardResponse.LabelResponse(1L, "SOPT"),
@@ -819,6 +820,7 @@ class MemoControllerTest {
                             0,
                             true,  // isPinned
                             false,
+                            true,
                             LocalDateTime.now(),
                             List.of()  // 라벨 없음
                     );
@@ -873,6 +875,7 @@ class MemoControllerTest {
                             0,
                             false,
                             false,
+                            true,
                             LocalDateTime.now(),
                             List.of(
                                     new MemoListDashboardResponse.LabelResponse(1L, "SOPT")


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #95 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 메모 최초 생성시 (AI 메모 포함) isNew=ture 로 생성됩니다.
- 메모 상세 조회시 isNew=false 로 업데이트합니다. + 조회 메서드에 DB영속성을 위한 트랜잭션 어노테이션을 추가했습니다.
- 메모 대시보드 전체조쇠히 각 메모별 isNew를 조회할 수 있습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메모의 읽음/미확인(isNew) 상태를 저장 및 표시합니다.
  * 메모 상세 조회 시 해당 메모가 자동으로 읽음 상태로 변경되어 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->