### PR TITLE
[Feat] AI 채팅 히스토리 및 RAG 예외 핸들링

### DIFF
--- a/src/main/java/org/project/domain/ai/controller/MemoAiController.java
+++ b/src/main/java/org/project/domain/ai/controller/MemoAiController.java
@@ -12,6 +12,7 @@ import org.project.domain.ai.dto.response.MemoAiResponseForPlan;
 import org.project.domain.ai.rag.pipeline.RagPipeline;
 import org.project.domain.ai.service.AiEvaluationService;
 import org.project.domain.ai.service.ChatRoomService;
+import org.project.domain.ai.service.MemoAiService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,8 @@ public class MemoAiController {
     private final RagPipeline ragPipeline;
     private final AiEvaluationService aiEvaluationService;
     private final ChatRoomService chatRoomService;
+
+    private final MemoAiService memoAiService;
 
 
     @Operation(
@@ -53,12 +56,8 @@ public class MemoAiController {
             @Valid @RequestBody MemoAiRequest request
     ) {
 
-        Long userId = userDetails.getUserId();
-
-        chatRoomService.validateAccess(userId, chatRoomId);
-
-        MemoAiResponse response = ragPipeline.run(
-                userId,
+        MemoAiResponse response = memoAiService.generate(
+                userDetails.getUserId(),
                 chatRoomId,
                 request
         );

--- a/src/main/java/org/project/domain/ai/controller/MemoAiController.java
+++ b/src/main/java/org/project/domain/ai/controller/MemoAiController.java
@@ -117,44 +117,13 @@ public class MemoAiController {
             @Valid @RequestBody MemoAiRequestForPlan request
     ) {
 
-        Long userId = userDetails.getUserId();
-
-        chatRoomService.validateAccess(userId, chatRoomId);
-
-        // AI 요청 DTO 구성
-        MemoAiRequest memoRequest =
-                MemoAiRequest.of(
-                        request.userPrompt(),
-                        request.option(),
-                        request.memoIds()
-                );
-
-        // AI 응답 생성
-        MemoAiResponse aiResponse =
-                ragPipeline.runForPlan(
-                        userId,
-                        chatRoomId,
-                        memoRequest,
-                        request.systemPrompt(),
-                        request.model(),
-                        request.temperature()
-                );
-
-        // AI 응답 품질 평가
-        AiEvaluationResult evaluationResult =
-                aiEvaluationService.evaluate(
-                        request.userPrompt(),
-                        aiResponse
-                );
-
-        // 응답 결합
         MemoAiResponseForPlan response =
-                MemoAiResponseForPlan.of(
-                        aiResponse,
-                        evaluationResult
+                memoAiService.generateForPlan(
+                        userDetails.getUserId(),
+                        chatRoomId,
+                        request
                 );
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
-
 }

--- a/src/main/java/org/project/domain/ai/rag/F/augment/DefaultRagAugmenter.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/DefaultRagAugmenter.java
@@ -2,7 +2,10 @@ package org.project.domain.ai.rag.F.augment;
 
 import lombok.RequiredArgsConstructor;
 import org.project.domain.ai.rag.D.query.dto.RagQuery;
+import org.project.domain.ai.rag.F.augment.context.RagContextBuilder;
+import org.project.domain.ai.rag.F.augment.context.RagContextPolicy;
 import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
+import org.project.domain.ai.rag.F.augment.system.SystemPromptResolver;
 import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +30,9 @@ public class DefaultRagAugmenter implements RagAugmenter {
         // Context 생성 (retrieved documents)
         String context =
                 contextBuilder.build(documents);
+
+        // 메모 컨텍스트 검증
+        RagContextPolicy.validateContext(context);
 
         // RagPrompt 생성
         return RagPrompt.of(

--- a/src/main/java/org/project/domain/ai/rag/F/augment/DefaultRagAugmenter.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/DefaultRagAugmenter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.project.domain.ai.rag.D.query.dto.RagQuery;
 import org.project.domain.ai.rag.F.augment.context.RagContextBuilder;
 import org.project.domain.ai.rag.F.augment.context.RagContextPolicy;
+import org.project.domain.ai.rag.F.augment.dto.RagContextResult;
 import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
 import org.project.domain.ai.rag.F.augment.system.SystemPromptResolver;
 import org.springframework.ai.document.Document;
@@ -28,17 +29,17 @@ public class DefaultRagAugmenter implements RagAugmenter {
                 systemPromptResolver.resolve(query.option());
 
         // Context 생성 (retrieved documents)
-        String context =
+        RagContextResult contextResult =
                 contextBuilder.build(documents);
 
         // 메모 컨텍스트 검증
-        RagContextPolicy.validateContext(context);
+        RagContextPolicy.validateContext(contextResult.pureTextLength());
 
         // RagPrompt 생성
         return RagPrompt.of(
                 systemPrompt,
                 query.userPrompt(),
-                context
+                contextResult.context()
         );
     }
 }

--- a/src/main/java/org/project/domain/ai/rag/F/augment/RagContextBuilder.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/RagContextBuilder.java
@@ -30,7 +30,7 @@ public class RagContextBuilder {
         }
 
         return """
-        [SOURCE]
+        [MEMO]
         %s
         """.formatted(
                 document.getText().trim()

--- a/src/main/java/org/project/domain/ai/rag/F/augment/RagContextBuilder.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/RagContextBuilder.java
@@ -16,41 +16,24 @@ public class RagContextBuilder {
 
         return documents.stream()
                 .map(this::formatDocument)
+                .filter(s -> !s.isBlank())
                 .collect(Collectors.joining("\n\n"));
     }
 
     private String formatDocument(Document document) {
 
-        String type = String.valueOf(
-                document.getMetadata().get("type")
-        );
+        String type = String.valueOf(document.getMetadata().get("type"));
 
+        // 메모 계열만 허용
         if (!type.startsWith("MEMO_")) {
             return "";
         }
 
-        String source = String.valueOf(
-                document.getMetadata().getOrDefault("rag_source", "unknown")
-        );
-
-        String fileName = String.valueOf(
-                document.getMetadata().getOrDefault("fileName", "")
-        );
-
-        String memoId = String.valueOf(
-                document.getMetadata().getOrDefault("memoId", "")
-        );
-
-        String sourceLabel = fileName.isBlank()
-                ? source + " | memoId=" + memoId
-                : source + " | " + fileName + " | memoId=" + memoId;
-
         return """
-        [SOURCE: %s]
+        [SOURCE]
         %s
         """.formatted(
-                sourceLabel,
-                document.getText()
+                document.getText().trim()
         );
     }
 }

--- a/src/main/java/org/project/domain/ai/rag/F/augment/SystemPromptResolver.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/SystemPromptResolver.java
@@ -18,6 +18,7 @@ public class SystemPromptResolver {
                     1. First line: Title
                     2. From the second line: Body content
                     - Do NOT apply any Markdown syntax to the title.
+                    - The entire response MUST be written in Korean. Do NOT use any other language.
                     
                     [CONTENT UNDERSTANDING RULES]
                     - All content provided after [CONTEXT] and each [SOURCE] is written by the user.
@@ -69,6 +70,7 @@ public class SystemPromptResolver {
                       1. First line: Title
                       2. From the second line: Body content
                     - Do NOT apply any Markdown syntax to the title.
+                    - The entire response MUST be written in Korean. Do NOT use any other language.
 
                     [CONTENT GENERATION RULES]
                     - The title must summarize the entire document at a high level.
@@ -111,6 +113,7 @@ public class SystemPromptResolver {
                       1. First line: Title
                       2. From the second line: Body
                     - Do NOT apply any Markdown syntax to the title.
+                    - The entire response MUST be written in Korean. Do NOT use any other language.
                     
                     [CONTEXT RULE]
                     - All content appearing after [CONTEXT] and each [SOURCE] is written by the user.
@@ -160,6 +163,7 @@ public class SystemPromptResolver {
                       1. First line: Title
                       2. From the second line: Body
                     - Do NOT apply any Markdown syntax to the title.
+                    - The entire response MUST be written in Korean. Do NOT use any other language.
 
                     [CONTEXT RULE]
                     - All content appearing after [CONTEXT] and each [SOURCE] is written by the user.

--- a/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextBuilder.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextBuilder.java
@@ -1,5 +1,6 @@
 package org.project.domain.ai.rag.F.augment.context;
 
+import org.project.domain.ai.rag.F.augment.dto.RagContextResult;
 import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Component;
 
@@ -9,19 +10,26 @@ import java.util.stream.Collectors;
 @Component
 public class RagContextBuilder {
 
-    public String build(List<Document> documents) {
+    public RagContextResult build(List<Document> documents) {
         if (documents == null || documents.isEmpty()) {
-            return "";
+            return new RagContextResult("", 0);
         }
 
-        return documents.stream()
+        String context = documents.stream()
                 .map(this::formatDocument)
                 .filter(s -> !s.isBlank())
                 .collect(Collectors.joining("\n\n"));
+
+        int pureTextLength = documents.stream()
+                .map(this::extractPureText)
+                .filter(s -> !s.isBlank())
+                .mapToInt(String::length)
+                .sum();
+
+        return new RagContextResult(context, pureTextLength);
     }
 
     private String formatDocument(Document document) {
-
         String type = String.valueOf(document.getMetadata().get("type"));
 
         // 메모 계열만 허용
@@ -29,11 +37,25 @@ public class RagContextBuilder {
             return "";
         }
 
+        String text = document.getText();
+        if (text == null || text.isBlank()) {
+            return "";
+        }
+
         return """
         [MEMO]
         %s
-        """.formatted(
-                document.getText().trim()
-        );
+        """.formatted(text.trim());
+    }
+
+    private String extractPureText(Document document) {
+        String type = String.valueOf(document.getMetadata().get("type"));
+
+        if (!type.startsWith("MEMO_")) {
+            return "";
+        }
+
+        String text = document.getText();
+        return text == null ? "" : text.trim();
     }
 }

--- a/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextBuilder.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextBuilder.java
@@ -1,4 +1,4 @@
-package org.project.domain.ai.rag.F.augment;
+package org.project.domain.ai.rag.F.augment.context;
 
 import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
@@ -8,14 +8,14 @@ public final class RagContextPolicy {
 
     public static final int MIN_CONTEXT_LENGTH = 200;
 
-    public static void validateContext(String context) {
-        if (context == null || context.isBlank()) {
+    public static void validateContext(int pureTextLength) {
+        if (pureTextLength <= 0) {
             throw new InsufficientRagContextException(
                     "선택된 메모에 유효한 내용이 없습니다."
             );
         }
 
-        if (context.length() < RagContextPolicy.MIN_CONTEXT_LENGTH) {
+        if (pureTextLength < MIN_CONTEXT_LENGTH) {
             throw new InsufficientRagContextException(
                     "선택된 메모의 길이가 너무 짧아\n" +
                     "의미 있는 답변을 생성할 수 없습니다."

--- a/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
@@ -1,0 +1,26 @@
+package org.project.domain.ai.rag.F.augment.context;
+
+import lombok.NoArgsConstructor;
+import org.project.global.exception.InsufficientRagContextException;
+
+@NoArgsConstructor
+public final class RagContextPolicy {
+
+    public static final int MIN_CONTEXT_LENGTH = 200;
+
+    public static void validateContext(String context) {
+        if (context == null || context.isBlank()) {
+            throw new InsufficientRagContextException(
+                    "선택된 메모에 유효한 내용이 없습니다."
+            );
+        }
+
+        if (context.length() < RagContextPolicy.MIN_CONTEXT_LENGTH) {
+            throw new InsufficientRagContextException(
+                    "선택된 메모의 길이가 너무 짧아 " +
+                            "의미 있는 답변을 생성할 수 없습니다."
+            );
+        }
+    }
+}
+

--- a/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/context/RagContextPolicy.java
@@ -17,8 +17,8 @@ public final class RagContextPolicy {
 
         if (context.length() < RagContextPolicy.MIN_CONTEXT_LENGTH) {
             throw new InsufficientRagContextException(
-                    "선택된 메모의 길이가 너무 짧아 " +
-                            "의미 있는 답변을 생성할 수 없습니다."
+                    "선택된 메모의 길이가 너무 짧아\n" +
+                    "의미 있는 답변을 생성할 수 없습니다."
             );
         }
     }

--- a/src/main/java/org/project/domain/ai/rag/F/augment/dto/RagContextResult.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/dto/RagContextResult.java
@@ -1,0 +1,7 @@
+package org.project.domain.ai.rag.F.augment.dto;
+
+public record RagContextResult(
+        String context,        // [MEMO] 포함된 RAG CONTEXT
+        int pureTextLength     // [MEMO] 제거된 순수 메모 텍스트 글자 수
+) {
+}

--- a/src/main/java/org/project/domain/ai/rag/F/augment/system/SystemPromptResolver.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/system/SystemPromptResolver.java
@@ -1,4 +1,4 @@
-package org.project.domain.ai.rag.F.augment;
+package org.project.domain.ai.rag.F.augment.system;
 
 import org.project.domain.ai.dto.MemoAiOptions;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
+++ b/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
@@ -3,9 +3,11 @@ package org.project.domain.ai.rag.G.generate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
+import org.project.domain.ai.rag.history.JpaAiCallHistoryWriter;
 import org.project.global.exception.domainException.AiException;
 import org.project.global.exception.errorcode.AiErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.retry.annotation.Backoff;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class DefaultRagGenerator implements RagGenerator {
 
     private final ChatClient chatClient;
+    private final JpaAiCallHistoryWriter historyWriter;
 
     @Retryable(
             maxAttempts = 3,
@@ -27,15 +30,18 @@ public class DefaultRagGenerator implements RagGenerator {
     @Override
     public String generate(RagPrompt prompt) {
 
+        String fullPrompt = buildFullPrompt(prompt);
+        long startTime = System.currentTimeMillis();
+
         try {
-            var response = chatClient
+            var responseSpec = chatClient
                     .prompt()
                     .system("""
-                %s
+                        %s
 
-                [CONTEXT]
-                %s
-                """.formatted(
+                        [CONTEXT]
+                        %s
+                        """.formatted(
                             prompt.systemPrompt(),
                             prompt.context()
                     ))
@@ -47,29 +53,49 @@ public class DefaultRagGenerator implements RagGenerator {
                     .call()
                     .chatClientResponse();
 
-            log.debug("Advisor context: {}", response.context());
-            var chatResponse = response.chatResponse();
-            var result = chatResponse != null ? chatResponse.getResult() : null;
-            var output = result != null ? result.getOutput() : null;
-            var text = output != null ? output.getText() : null;
-            if (text == null || text.isBlank()) {
-                log.warn("AI 응답 text가 비어 있습니다. contextKeys={}",
-                        response.context() != null ? response.context().keySet() : "null");
-                throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
-            }
+            String text = extractText(responseSpec);
+
+            long latency = System.currentTimeMillis() - startTime;
+
+            historyWriter.saveSuccess(
+                    prompt,
+                    fullPrompt,
+                    text,
+                    latency
+            );
+
+            log.info(
+                    "AI generation success [conversationId={}, latency={}ms, responseLength={}]",
+                    prompt.conversationId(),
+                    latency,
+                    text.length()
+            );
+
             return text;
+
         } catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            log.error("AI 호출 실패", e);
             throw e;
         }
     }
 
     @Recover
     public String recover(Exception e, RagPrompt prompt) {
-        log.error("AI 생성 최종 실패 after 3 attempts: {}", e.getMessage(), e);
+
+        String fullPrompt = buildFullPrompt(prompt);
+
+        historyWriter.saveFailure(
+                prompt,
+                fullPrompt,
+                e
+        );
+
+        log.error(
+                "AI generation failed after retries [conversationId={}, error={}]",
+                prompt.conversationId(),
+                e.getMessage(),
+                e
+        );
+
         throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
     }
 
@@ -109,5 +135,46 @@ public class DefaultRagGenerator implements RagGenerator {
     public String recoverForPlan(Exception e, RagPrompt prompt, String model, Double temperature) {
         log.error("Plan AI 생성 최종 실패 after 3 attempts: {}", e.getMessage(), e);
         throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
+    }
+
+
+    /* =========================
+       Helper Methods
+       ========================= */
+
+    private String buildFullPrompt(RagPrompt prompt) {
+        return """
+            [SYSTEM]
+            %s
+
+            [CONTEXT]
+            %s
+
+            [USER]
+            %s
+            """.formatted(
+                prompt.systemPrompt(),
+                prompt.context(),
+                prompt.userPrompt()
+        );
+    }
+
+    private String extractText(ChatClientResponse response) {
+
+        if (response == null || response.chatResponse() == null) {
+            throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
+        }
+
+        var result = response.chatResponse().getResult();
+        if (result == null || result.getOutput() == null) {
+            throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
+        }
+
+        String text = result.getOutput().getText();
+        if (text == null || text.isBlank()) {
+            throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
+        }
+
+        return text;
     }
 }

--- a/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
+++ b/src/main/java/org/project/domain/ai/rag/G/generate/DefaultRagGenerator.java
@@ -106,36 +106,85 @@ public class DefaultRagGenerator implements RagGenerator {
     )
     public String generateForPlan(RagPrompt prompt, String model, Double temperature) {
 
-        return chatClient
-                .prompt()
-                .options(ChatOptions.builder()
-                        .model(model)
-                        .temperature(temperature)
-                        .build()
-                )
-                .system("""
-                %s
+        String fullPrompt = buildFullPrompt(prompt);
+        long startTime = System.currentTimeMillis();
 
-                [CONTEXT]
-                %s
-                """.formatted(
-                        prompt.systemPrompt(),
-                        prompt.context()
-                ))
-                .user(prompt.userPrompt())
-                .advisors(a -> a.param(
-                        ChatMemory.CONVERSATION_ID,
-                        prompt.conversationId()
-                ))
-                .call()
-                .content();
+        try {
+            var response = chatClient
+                    .prompt()
+                    .options(ChatOptions.builder()
+                            .model(model)
+                            .temperature(temperature)
+                            .build()
+                    )
+                    .system("""
+                    %s
+
+                    [CONTEXT]
+                    %s
+                    """.formatted(
+                            prompt.systemPrompt(),
+                            prompt.context()
+                    ))
+                    .user(prompt.userPrompt())
+                    .advisors(a -> a.param(
+                            ChatMemory.CONVERSATION_ID,
+                            prompt.conversationId()
+                    ))
+                    .call()
+                    .chatClientResponse();
+
+            String text = extractText(response);
+
+            long latency = System.currentTimeMillis() - startTime;
+
+            historyWriter.saveSuccess(
+                    prompt,
+                    fullPrompt,
+                    text,
+                    latency
+            );
+
+            log.info(
+                    "Plan AI generation success [conversationId={}, model={}, temperature={}, latency={}ms]",
+                    prompt.conversationId(),
+                    model,
+                    temperature,
+                    latency
+            );
+
+            return text;
+
+        } catch (Exception e) {
+            throw e;
+        }
     }
+
 
     @Recover
     public String recoverForPlan(Exception e, RagPrompt prompt, String model, Double temperature) {
-        log.error("Plan AI 생성 최종 실패 after 3 attempts: {}", e.getMessage(), e);
+
+        String fullPrompt = buildFullPrompt(prompt);
+
+        historyWriter.saveFailure(
+                prompt,
+                fullPrompt,
+                e
+        );
+
+        log.error(
+                "Plan AI generation failed after retries " +
+                        "[conversationId={}, model={}, temperature={}, error={}]",
+                prompt.conversationId(),
+                model,
+                temperature,
+                e.getMessage(),
+                e
+        );
+
         throw new AiException(AiErrorCode.AI_GENERATION_FAILED);
     }
+
 
 
     /* =========================

--- a/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRecord.java
+++ b/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRecord.java
@@ -20,25 +20,26 @@ public class AiCallHistoryRecord {
 
     private String conversationId;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String systemPrompt;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String context;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String userPrompt;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String fullPrompt;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String responseText;
 
     private boolean success;
 
     private Long latencyMs;
 
+    @Column(columnDefinition = "TEXT")
     private String errorMessage;
 
     private LocalDateTime createdAt;
@@ -87,4 +88,3 @@ public class AiCallHistoryRecord {
                 : e.getMessage();
     }
 }
-

--- a/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRecord.java
+++ b/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRecord.java
@@ -1,0 +1,90 @@
+package org.project.domain.ai.rag.history;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ai_call_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiCallHistoryRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String conversationId;
+
+    @Lob
+    private String systemPrompt;
+
+    @Lob
+    private String context;
+
+    @Lob
+    private String userPrompt;
+
+    @Lob
+    private String fullPrompt;
+
+    @Lob
+    private String responseText;
+
+    private boolean success;
+
+    private Long latencyMs;
+
+    private String errorMessage;
+
+    private LocalDateTime createdAt;
+
+    /* 정적 팩토리 메서드 */
+    public static AiCallHistoryRecord success(
+            RagPrompt prompt,
+            String fullPrompt,
+            String responseText,
+            long latencyMs
+    ) {
+        AiCallHistoryRecord r = new AiCallHistoryRecord();
+        r.conversationId = prompt.conversationId();
+        r.systemPrompt = prompt.systemPrompt();
+        r.context = prompt.context();
+        r.userPrompt = prompt.userPrompt();
+        r.fullPrompt = fullPrompt;
+        r.responseText = responseText;
+        r.success = true;
+        r.latencyMs = latencyMs;
+        r.createdAt = LocalDateTime.now();
+        return r;
+    }
+
+    public static AiCallHistoryRecord failure(
+            RagPrompt prompt,
+            String fullPrompt,
+            Exception e
+    ) {
+        AiCallHistoryRecord r = new AiCallHistoryRecord();
+        r.conversationId = prompt.conversationId();
+        r.systemPrompt = prompt.systemPrompt();
+        r.context = prompt.context();
+        r.userPrompt = prompt.userPrompt();
+        r.fullPrompt = fullPrompt;
+        r.success = false;
+        r.errorMessage = safeMessage(e);
+        r.createdAt = LocalDateTime.now();
+        return r;
+    }
+
+    private static String safeMessage(Exception e) {
+        if (e == null || e.getMessage() == null) return null;
+        return e.getMessage().length() > 2000
+                ? e.getMessage().substring(0, 2000)
+                : e.getMessage();
+    }
+}
+

--- a/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRepository.java
+++ b/src/main/java/org/project/domain/ai/rag/history/AiCallHistoryRepository.java
@@ -1,0 +1,6 @@
+package org.project.domain.ai.rag.history;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiCallHistoryRepository extends JpaRepository<AiCallHistoryRecord, Long> {
+}

--- a/src/main/java/org/project/domain/ai/rag/history/JpaAiCallHistoryWriter.java
+++ b/src/main/java/org/project/domain/ai/rag/history/JpaAiCallHistoryWriter.java
@@ -1,0 +1,52 @@
+package org.project.domain.ai.rag.history;
+
+import lombok.RequiredArgsConstructor;
+import org.project.domain.ai.rag.F.augment.dto.RagPrompt;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class JpaAiCallHistoryWriter {
+
+    private final AiCallHistoryRepository repository;
+
+    /**
+     * AI 호출 성공 기록
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveSuccess(
+            RagPrompt prompt,
+            String fullPrompt,
+            String responseText,
+            long latencyMs
+    ) {
+        repository.save(
+                AiCallHistoryRecord.success(
+                        prompt,
+                        fullPrompt,
+                        responseText,
+                        latencyMs
+                )
+        );
+    }
+
+    /**
+     * AI 호출 실패 기록
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailure(
+            RagPrompt prompt,
+            String fullPrompt,
+            Exception e
+    ) {
+        repository.save(
+                AiCallHistoryRecord.failure(
+                        prompt,
+                        fullPrompt,
+                        e
+                )
+        );
+    }
+}

--- a/src/main/java/org/project/domain/ai/service/AiEvaluationServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/AiEvaluationServiceImpl.java
@@ -110,17 +110,17 @@ public class AiEvaluationServiceImpl implements AiEvaluationService {
      * 헬퍼 메서드
      */
     private List<String> extractRagContexts(String usedPrompt) {
-        if (!usedPrompt.contains("[CONTEXT]")) return List.of();
+        if (usedPrompt == null || !usedPrompt.contains("[CONTEXT]")) {
+            return List.of();
+        }
 
         String contextPart =
-                usedPrompt.substring(usedPrompt.indexOf("[CONTEXT]"));
+                usedPrompt.substring(
+                        usedPrompt.indexOf("[CONTEXT]") + "[CONTEXT]".length()
+                );
 
-        return Arrays.stream(contextPart.split("\\[SOURCE:"))
-                .skip(1)
-                .map(s -> {
-                    int idx = s.indexOf("]");
-                    return idx >= 0 ? s.substring(idx + 1).trim() : s.trim();
-                    })
+        return Arrays.stream(contextPart.split("\\[MEMO\\]"))
+                .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();
     }

--- a/src/main/java/org/project/domain/ai/service/MemoAiService.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiService.java
@@ -1,0 +1,13 @@
+package org.project.domain.ai.service;
+
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+
+public interface MemoAiService {
+
+    MemoAiResponse generate(
+            Long userId,
+            Long chatRoomId,
+            MemoAiRequest request
+    );
+}

--- a/src/main/java/org/project/domain/ai/service/MemoAiService.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiService.java
@@ -1,7 +1,9 @@
 package org.project.domain.ai.service;
 
 import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.request.MemoAiRequestForPlan;
 import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.dto.response.MemoAiResponseForPlan;
 
 public interface MemoAiService {
 
@@ -9,5 +11,11 @@ public interface MemoAiService {
             Long userId,
             Long chatRoomId,
             MemoAiRequest request
+    );
+
+    MemoAiResponseForPlan generateForPlan(
+            Long userId,
+            Long chatRoomId,
+            MemoAiRequestForPlan request
     );
 }

--- a/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
@@ -1,0 +1,33 @@
+package org.project.domain.ai.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.rag.pipeline.RagPipeline;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemoAiServiceImpl implements MemoAiService {
+
+    private final RagPipeline ragPipeline;
+    private final ChatRoomService chatRoomService;
+
+    @Override
+    public MemoAiResponse generate(
+            Long userId,
+            Long chatRoomId,
+            MemoAiRequest request
+    ) {
+
+        // 접근 검증
+        chatRoomService.validateAccess(userId, chatRoomId);
+
+        // 파이프라인 실행
+        return ragPipeline.run(
+                userId,
+                chatRoomId,
+                request
+        );
+    }
+}

--- a/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
@@ -2,7 +2,10 @@ package org.project.domain.ai.service;
 
 import lombok.RequiredArgsConstructor;
 import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.request.MemoAiRequestForPlan;
+import org.project.domain.ai.dto.response.AiEvaluationResult;
 import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.dto.response.MemoAiResponseForPlan;
 import org.project.domain.ai.rag.pipeline.RagPipeline;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +15,8 @@ public class MemoAiServiceImpl implements MemoAiService {
 
     private final RagPipeline ragPipeline;
     private final ChatRoomService chatRoomService;
+
+    private final AiEvaluationService aiEvaluationService;
 
     @Override
     public MemoAiResponse generate(
@@ -28,6 +33,47 @@ public class MemoAiServiceImpl implements MemoAiService {
                 userId,
                 chatRoomId,
                 request
+        );
+    }
+
+    @Override
+    public MemoAiResponseForPlan generateForPlan(
+            Long userId,
+            Long chatRoomId,
+            MemoAiRequestForPlan request
+    ) {
+
+        // 채팅방 접근 검증
+        chatRoomService.validateAccess(userId, chatRoomId);
+
+        // 내부 공통 AI 요청 DTO로 변환
+        MemoAiRequest memoRequest = MemoAiRequest.of(
+                request.userPrompt(),
+                request.option(),
+                request.memoIds()
+        );
+
+        // AI 응답 생성
+        MemoAiResponse aiResponse = ragPipeline.runForPlan(
+                userId,
+                chatRoomId,
+                memoRequest,
+                request.systemPrompt(),
+                request.model(),
+                request.temperature()
+        );
+
+        // AI 응답 품질 평가
+        AiEvaluationResult evaluationResult =
+                aiEvaluationService.evaluate(
+                        request.userPrompt(),
+                        aiResponse
+                );
+
+        // 응답 조립
+        return MemoAiResponseForPlan.of(
+                aiResponse,
+                evaluationResult
         );
     }
 }

--- a/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
@@ -7,6 +7,7 @@ import org.project.domain.ai.dto.response.AiEvaluationResult;
 import org.project.domain.ai.dto.response.MemoAiResponse;
 import org.project.domain.ai.dto.response.MemoAiResponseForPlan;
 import org.project.domain.ai.rag.pipeline.RagPipeline;
+import org.project.global.exception.InsufficientRagContextException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,12 +29,24 @@ public class MemoAiServiceImpl implements MemoAiService {
         // 접근 검증
         chatRoomService.validateAccess(userId, chatRoomId);
 
-        // 파이프라인 실행
-        return ragPipeline.run(
-                userId,
-                chatRoomId,
-                request
-        );
+        try {
+            // 정상 RAG 파이프라인 실행
+            return ragPipeline.run(
+                    userId,
+                    chatRoomId,
+                    request
+            );
+
+        } catch (InsufficientRagContextException e) {
+
+            return MemoAiResponse.of(
+                    /* title */ "AI 응답을 생성할 수 없습니다",
+                    /* content */ e.getMessage(),
+                    /* option */ request.option(),
+                    /* memoIds */ request.memoIds(),
+                    /* debug */ null   // or "CONTEXT_TOO_SHORT"
+            );
+        }
     }
 
     @Override
@@ -53,27 +66,54 @@ public class MemoAiServiceImpl implements MemoAiService {
                 request.memoIds()
         );
 
-        // AI 응답 생성
-        MemoAiResponse aiResponse = ragPipeline.runForPlan(
-                userId,
-                chatRoomId,
-                memoRequest,
-                request.systemPrompt(),
-                request.model(),
-                request.temperature()
-        );
+        try {
+            // AI 응답 생성
+            MemoAiResponse aiResponse = ragPipeline.runForPlan(
+                    userId,
+                    chatRoomId,
+                    memoRequest,
+                    request.systemPrompt(),
+                    request.model(),
+                    request.temperature()
+            );
 
-        // AI 응답 품질 평가
-        AiEvaluationResult evaluationResult =
-                aiEvaluationService.evaluate(
-                        request.userPrompt(),
-                        aiResponse
-                );
+            // AI 응답 품질 평가
+            AiEvaluationResult evaluationResult =
+                    aiEvaluationService.evaluate(
+                            request.userPrompt(),
+                            aiResponse
+                    );
 
-        // 응답 조립
-        return MemoAiResponseForPlan.of(
-                aiResponse,
-                evaluationResult
-        );
+            // 정상 응답
+            return MemoAiResponseForPlan.of(
+                    aiResponse,
+                    evaluationResult
+            );
+
+        } catch (InsufficientRagContextException e) {
+            // 컨텍스트 부족 → AI 응답처럼 치환
+
+            MemoAiResponse fallbackResponse = MemoAiResponse.of(
+                    "AI 응답을 생성할 수 없습니다",
+                    e.getMessage(),
+                    request.option(),
+                    request.memoIds(),
+                    null
+            );
+
+            // 컨텍스트 부족은 "평가 대상 아님"
+            AiEvaluationResult emptyEvaluation =
+                    AiEvaluationResult.of(
+                            0.0,
+                            0.0,
+                            0.0,
+                            false
+                    );
+
+            return MemoAiResponseForPlan.of(
+                    fallbackResponse,
+                    emptyEvaluation
+            );
+        }
     }
 }

--- a/src/main/java/org/project/domain/label/controller/LabelController.java
+++ b/src/main/java/org/project/domain/label/controller/LabelController.java
@@ -3,7 +3,7 @@ package org.project.domain.label.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.project.domain.label.dto.reponse.LabelListResponse;
+import org.project.domain.label.dto.response.LabelListResponse;
 import org.project.domain.label.service.LabelService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.global.response.ApiResponse;

--- a/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
@@ -1,4 +1,4 @@
-package org.project.domain.label.dto.reponse;
+package org.project.domain.label.dto.response;
 
 import org.project.domain.label.entity.Label;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;

--- a/src/main/java/org/project/domain/label/service/LabelService.java
+++ b/src/main/java/org/project/domain/label/service/LabelService.java
@@ -1,6 +1,6 @@
 package org.project.domain.label.service;
 
-import org.project.domain.label.dto.reponse.LabelListResponse;
+import org.project.domain.label.dto.response.LabelListResponse;
 
 public interface LabelService {
 

--- a/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
+++ b/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
@@ -1,7 +1,7 @@
 package org.project.domain.label.service;
 
 import lombok.RequiredArgsConstructor;
-import org.project.domain.label.dto.reponse.LabelListResponse;
+import org.project.domain.label.dto.response.LabelListResponse;
 import org.project.domain.label.entity.Label;
 import org.project.domain.label.repository.LabelRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/project/global/exception/InsufficientRagContextException.java
+++ b/src/main/java/org/project/global/exception/InsufficientRagContextException.java
@@ -1,0 +1,9 @@
+package org.project.global.exception;
+
+public class InsufficientRagContextException extends RuntimeException {
+
+    public InsufficientRagContextException(String message) {
+      super(message);
+    }
+}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -59,7 +59,7 @@ spring:
 
         chat:
           options:
-            model: gemini-3-flash-preview
+            model: gemini-2.5-flash-lite
             temperature: 0.7
             candidate-count: 1
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -59,7 +59,7 @@ spring:
 
         chat:
           options:
-            model: gemini-3-flash-preview
+            model: gemini-2.5-flash-lite
             temperature: 0.7
             candidate-count: 1
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -61,7 +61,7 @@ spring:
 
         chat:
           options:
-            model: gemini-3-flash-preview
+            model: gemini-2.5-flash-lite
             temperature: 0.7
             candidate-count: 1
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #108 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- AI 채팅시 DB에 히스토리를 저장합니다.
- 컨텍스트가 짧을때 응답을 예상치 못하게 뱉는 경우가 많아 메모 내용이 짧으면 예외를 터트립니다.
- 해당 예외는 서비스 레이어에서 AI응답을 커스텀 조합하여 응답합니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 생성 호출 이력 저장 및 조회용 기록 기능 추가
  * 메모 기반 AI 요청용 서비스 인터페이스 추가

* **개선 사항**
  * 선택된 메모 컨텍스트 유효성 검사 강화(최소 길이 검증)
  * AI 응답 생성 흐름 안정성 및 오류 복구 향상
  * AI 출력이 한국어로만 나오도록 규칙 적용

* **업데이트**
  * 기본 AI 모델을 gemini-2.5-flash-lite로 전환
  * 레이블 모듈 패키지 경로 오류 수정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->