### PR TITLE
[CHORE] Google OAuth callback 응답 파라미터를 code만 전달하도록 정리

### DIFF
--- a/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
+++ b/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
@@ -9,6 +9,8 @@ import org.project.domain.user.dto.CustomUserDetails;
 import org.project.domain.user.service.GoogleAuthService;
 import org.project.global.annotation.BusinessExceptionDescription;
 import org.project.global.config.swagger.SwaggerResponseDescription;
+import org.project.global.exception.domainException.LoginException;
+import org.project.global.exception.errorcode.LoginErrorCode;
 import org.project.global.response.ApiResponse;
 import org.project.global.security.properties.GoogleOAuthProperties;
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -26,6 +32,8 @@ public class GoogleOAuthController {
 
     private final GoogleOAuthProperties googleOAuthProperties;
     private final GoogleAuthService googleAuthService;
+    @org.springframework.beans.factory.annotation.Value("${app.oauth.frontend-callback-url:http://localhost:5173/oauth/callback}")
+    private String frontendCallbackUrl;
 
     @GetMapping("/oauth/google")
     @Operation(summary = "구글 소셜로그인 API",
@@ -51,15 +59,31 @@ public class GoogleOAuthController {
     }
 
     @Operation(summary = "구글 인증서버 토큰 검증 API",
-            description = "리다이렉트에서 AccessCode를 가지고 서버로 돌아오기 위한 엔드포인트입니다\n" +
-                    "해당 코드를 이용해서 사용자 정보를 파싱하고 액세스 토큰는 헤더에, 리프레시 토큰은 쿠키에 담아 반환합니다")
+            description = "구글 콜백에서 받은 인가코드로 로그인 처리를 한 뒤\n" +
+                    "프론트엔드의 콜백 URL로 code만 전달해 리다이렉트합니다.")
     @GetMapping("/oauth/google/callback")
     @BusinessExceptionDescription(SwaggerResponseDescription.GOOGLE_LOGIN_CALLBACK)
-    public ResponseEntity<ApiResponse<Void>> callback(
-            @RequestParam String code,
+    public ResponseEntity<Void> callback(
+            @RequestParam Map<String, String> params,
             HttpServletResponse response
     ) {
-        return googleAuthService.loginOrRegisterWithResponse(code, response);
+        String code = params.get("code");
+
+        if (code == null || code.isBlank()) {
+            throw new LoginException(LoginErrorCode.AUTH_SOCIAL_LOGIN_FAIL);
+        }
+
+        googleAuthService.loginOrRegisterWithResponse(code, response);
+
+        URI redirectUri = UriComponentsBuilder
+                .fromUriString(frontendCallbackUrl)
+                .queryParam("code", code)
+                .build(true)
+                .toUri();
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(redirectUri)
+                .build();
     }
 
     @Operation(summary = "로그아웃 API")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -97,6 +97,8 @@ app:
     domain: ".clustar.cloud"
     same-site: None
     secure: true
+  oauth:
+    frontend-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL:http://localhost:5173/oauth/callback}
 
 management:
   endpoint:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -97,6 +97,8 @@ app:
     domain: ".clustar.cloud"
     same-site: None
     secure: true
+  oauth:
+    frontend-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL:http://localhost:5173/oauth/callback}
 
 cloud:
   aws:

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -98,6 +98,8 @@ app:
     domain: ".clustar.cloud"
     same-site: None
     secure: true
+  oauth:
+    frontend-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL:http://localhost:5173/oauth/callback}
 
 management:
   endpoint:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -82,6 +82,8 @@ app:
     domain: ".clustar.cloud"
     same-site: None
     secure: true
+  oauth:
+    frontend-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL:http://localhost:5173/oauth/callback}
 
 cloud:
   aws:

--- a/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
+++ b/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
@@ -1,0 +1,56 @@
+package org.project.domain.user.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.user.service.GoogleAuthService;
+import org.project.global.response.ApiResponse;
+import org.project.global.security.filter.JWTFilter;
+import org.project.global.security.properties.GoogleOAuthProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GoogleOAuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("GoogleOAuthController 테스트")
+class GoogleOAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GoogleOAuthProperties googleOAuthProperties;
+
+    @MockBean
+    private GoogleAuthService googleAuthService;
+
+    @MockBean
+    private JWTFilter jwtFilter;
+
+    @Test
+    @DisplayName("Google 콜백은 code만 프론트 callback으로 전달한다")
+    void callback_redirects_only_code() throws Exception {
+        when(googleAuthService.loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class)))
+                .thenReturn(ResponseEntity.ok(ApiResponse.ok(null)));
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .queryParam("iss", "https://accounts.google.com")
+                        .queryParam("code", "abc123"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "http://localhost:5173/oauth/callback?code=abc123"));
+
+        verify(googleAuthService).loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class));
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #136

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Google OAuth 콜백 처리 후 프론트엔드로 redirect할 때 query parameter를 `code`만 전달하도록 수정
- Google 콜백 요청에서 들어오는 `iss` 등 불필요한 파라미터는 프론트로 넘기지 않도록 정리
- 프론트 콜백 URL을 설정값으로 분리
- `/oauth/google/callback` 콜백 응답이 `code`만 포함하는지 테스트 추가

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google OAuth 콜백 처리 방식을 개선하여 프론트엔드로의 리다이렉트 메커니즘으로 변경했습니다.

* **Tests**
  * Google OAuth 콜백 엔드포인트 리다이렉트 동작을 검증하는 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->