### PR TITLE
[FEATURE] 부모 태그 전체 조회 및 부모 태그 기반 하위 태그 조회 API 구현

### DIFF
--- a/src/main/java/org/project/domain/label/controller/LabelController.java
+++ b/src/main/java/org/project/domain/label/controller/LabelController.java
@@ -3,7 +3,9 @@ package org.project.domain.label.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelListResponse;
+import org.project.domain.label.dto.response.LabelParentListResponse;
 import org.project.domain.label.service.LabelService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.global.response.ApiResponse;
@@ -11,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +40,41 @@ public class LabelController {
 
         LabelListResponse response =
                 labelService.getAllLabels(userId);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(
+            summary = "부모 태그 전체 조회",
+            description = """
+            사용자의 부모 태그 최대 10개를 생성일 내림차순으로 조회합니다.
+            """
+    )
+    @GetMapping("/parents")
+    public ResponseEntity<ApiResponse<LabelParentListResponse>> getParentLabels(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        LabelParentListResponse response = labelService.getParentLabels(userId);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(
+            summary = "부모 태그 기반 하위 태그 조회",
+            description = """
+            부모 태그를 기준으로 자식 태그와 손자 태그를 계층 구조로 조회합니다.
+            """
+    )
+    @GetMapping("/parents/{parentLabelId}/children")
+    public ResponseEntity<ApiResponse<LabelHierarchyResponse>> getChildAndGrandChildLabels(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long parentLabelId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        LabelHierarchyResponse response = labelService.getChildAndGrandChildLabels(userId, parentLabelId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/src/main/java/org/project/domain/label/controller/LabelController.java
+++ b/src/main/java/org/project/domain/label/controller/LabelController.java
@@ -45,7 +45,7 @@ public class LabelController {
     }
 
     @Operation(
-            summary = "부모 태그 전체 조회",
+            summary = "부모 태그 최대 10개 조회",
             description = """
             사용자의 부모 태그 최대 10개를 생성일 내림차순으로 조회합니다.
             """

--- a/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
@@ -1,0 +1,43 @@
+package org.project.domain.label.dto.response;
+
+import org.project.domain.label.entity.Label;
+
+import java.util.List;
+import java.util.Map;
+
+public record LabelHierarchyResponse(
+        LabelSummaryResponse parentLabel,
+        List<LabelTreeResponse> childLabels
+) {
+    public static LabelHierarchyResponse from(Label parentLabel, List<Label> childLabels, Map<Long, List<Label>> grandChildLabelsByParentId) {
+        return new LabelHierarchyResponse(
+                LabelSummaryResponse.from(parentLabel),
+                childLabels.stream()
+                        .map(child -> LabelTreeResponse.from(
+                                child,
+                                grandChildLabelsByParentId.getOrDefault(child.getId(), List.of())
+                        ))
+                        .toList()
+        );
+    }
+
+    public record LabelTreeResponse(
+            Long labelId,
+            String name,
+            List<LabelTreeResponse> childLabels
+    ) {
+        public static LabelTreeResponse from(Label label, List<Label> childLabels) {
+            return new LabelTreeResponse(
+                    label.getId(),
+                    label.getName(),
+                    childLabels.stream()
+                            .map(child -> new LabelTreeResponse(
+                                    child.getId(),
+                                    child.getName(),
+                                    List.of()
+                            ))
+                            .toList()
+            );
+        }
+    }
+}

--- a/src/main/java/org/project/domain/label/dto/response/LabelParentListResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelParentListResponse.java
@@ -1,0 +1,18 @@
+package org.project.domain.label.dto.response;
+
+import org.project.domain.label.entity.Label;
+
+import java.util.List;
+
+public record LabelParentListResponse(
+        List<LabelSummaryResponse> labels
+) {
+
+    public static LabelParentListResponse from(List<Label> labelEntities) {
+        return new LabelParentListResponse(
+                labelEntities.stream()
+                        .map(LabelSummaryResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
@@ -1,0 +1,15 @@
+package org.project.domain.label.dto.response;
+
+import org.project.domain.label.entity.Label;
+
+public record LabelSummaryResponse(
+        Long labelId,
+        String name
+) {
+    public static LabelSummaryResponse from(Label label) {
+        return new LabelSummaryResponse(
+                label.getId(),
+                label.getName()
+        );
+    }
+}

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.project.domain.memo.entity.MemoLabel;
 import org.project.domain.user.entity.User;
+import org.project.global.entity.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "label")
-public class Label {
+public class Label extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +29,14 @@ public class Label {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_label_id")
+    private Label parent;
+
+    @OneToMany(mappedBy = "parent")
+    @Builder.Default
+    private List<Label> children = new ArrayList<>();
+
     @OneToMany(mappedBy = "label", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MemoLabel> memoLabels = new ArrayList<>();
@@ -36,6 +45,14 @@ public class Label {
         return Label.builder()
                 .name(name)
                 .user(user)
+                .build();
+    }
+
+    public static Label create(String name, User user, Label parent) {
+        return Label.builder()
+                .name(name)
+                .user(user)
+                .parent(parent)
                 .build();
     }
 

--- a/src/main/java/org/project/domain/label/repository/LabelRepository.java
+++ b/src/main/java/org/project/domain/label/repository/LabelRepository.java
@@ -11,4 +11,12 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
     Optional<Label> findByNameAndUser(String name, User user);
 
     List<Label> findAllByUserId(Long userId);
+
+    List<Label> findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc(Long userId);
+
+    Optional<Label> findByIdAndUserIdAndParentIsNull(Long id, Long userId);
+
+    List<Label> findByUserIdAndParentIdOrderByCreatedAtDesc(Long userId, Long parentId);
+
+    List<Label> findByUserIdAndParentParentIdOrderByCreatedAtDesc(Long userId, Long parentId);
 }

--- a/src/main/java/org/project/domain/label/service/LabelService.java
+++ b/src/main/java/org/project/domain/label/service/LabelService.java
@@ -1,8 +1,14 @@
 package org.project.domain.label.service;
 
 import org.project.domain.label.dto.response.LabelListResponse;
+import org.project.domain.label.dto.response.LabelHierarchyResponse;
+import org.project.domain.label.dto.response.LabelParentListResponse;
 
 public interface LabelService {
 
     LabelListResponse getAllLabels(Long userId);
+
+    LabelParentListResponse getParentLabels(Long userId);
+
+    LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentLabelId);
 }

--- a/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
+++ b/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
@@ -1,13 +1,19 @@
 package org.project.domain.label.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelListResponse;
+import org.project.domain.label.dto.response.LabelParentListResponse;
 import org.project.domain.label.entity.Label;
 import org.project.domain.label.repository.LabelRepository;
+import org.project.global.exception.domainException.LabelException;
+import org.project.global.exception.errorcode.LabelErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,5 +25,25 @@ public class LabelServiceImpl implements LabelService{
     public LabelListResponse getAllLabels(Long userId) {
         List<Label> labels = labelRepository.findAllByUserId(userId);
         return LabelListResponse.from(labels);
+    }
+
+    @Override
+    public LabelParentListResponse getParentLabels(Long userId) {
+        List<Label> labels = labelRepository.findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc(userId);
+        return LabelParentListResponse.from(labels);
+    }
+
+    @Override
+    public LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentLabelId) {
+        Label parentLabel = labelRepository.findByIdAndUserIdAndParentIsNull(parentLabelId, userId)
+                .orElseThrow(() -> new LabelException(LabelErrorCode.PARENT_LABEL_NOT_FOUND));
+
+        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, parentLabelId);
+        List<Label> grandChildLabels = labelRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(userId, parentLabelId);
+
+        Map<Long, List<Label>> grandChildLabelsByParentId = grandChildLabels.stream()
+                .collect(Collectors.groupingBy(label -> label.getParent().getId()));
+
+        return LabelHierarchyResponse.from(parentLabel, childLabels, grandChildLabelsByParentId);
     }
 }

--- a/src/main/java/org/project/global/exception/domainException/LabelException.java
+++ b/src/main/java/org/project/global/exception/domainException/LabelException.java
@@ -1,0 +1,10 @@
+package org.project.global.exception.domainException;
+
+import org.project.global.exception.BusinessException;
+import org.project.global.exception.errorcode.ErrorCode;
+
+public class LabelException extends BusinessException {
+    public LabelException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
@@ -1,0 +1,35 @@
+package org.project.global.exception.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum LabelErrorCode implements ErrorCode {
+
+    PARENT_LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "부모 태그를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String msg;
+
+    LabelErrorCode(HttpStatus status, int code, String msg) {
+        this.status = status;
+        this.code = code;
+        this.msg = msg;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/src/test/java/org/project/domain/label/repository/LabelRepositoryTest.java
+++ b/src/test/java/org/project/domain/label/repository/LabelRepositoryTest.java
@@ -1,0 +1,117 @@
+package org.project.domain.label.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.label.entity.Label;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.querydsl.QuerydslTestConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("LabelRepository 테스트")
+class LabelRepositoryTest {
+
+    @Autowired
+    private LabelRepository labelRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("부모 태그는 생성일 내림차순으로 최대 10개 조회된다")
+    void findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc_success() {
+        // given
+        User user = userRepository.save(createUser());
+
+        for (int i = 1; i <= 12; i++) {
+            Label label = Label.create("parent-" + i, user);
+            ReflectionTestUtils.setField(
+                    label,
+                    "createdAt",
+                    LocalDateTime.of(2026, 1, 1, 0, 0).plusMinutes(i)
+            );
+            labelRepository.save(label);
+        }
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Label> result = labelRepository.findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc(user.getId());
+
+        // then
+        assertThat(result).hasSize(10);
+        assertThat(result.get(0).getName()).isEqualTo("parent-12");
+        assertThat(result.get(9).getName()).isEqualTo("parent-3");
+    }
+
+    @Test
+    @DisplayName("자식과 손자 태그를 부모 기준으로 조회할 수 있다")
+    void findHierarchyByParent_success() {
+        // given
+        User user = userRepository.save(createUser());
+
+        Label parent = Label.create("parent", user);
+        ReflectionTestUtils.setField(parent, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 0));
+        labelRepository.save(parent);
+
+        Label child1 = Label.create("child-1", user, parent);
+        ReflectionTestUtils.setField(child1, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 10));
+        labelRepository.save(child1);
+
+        Label child2 = Label.create("child-2", user, parent);
+        ReflectionTestUtils.setField(child2, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 20));
+        labelRepository.save(child2);
+
+        Label grand1 = Label.create("grand-1", user, child1);
+        ReflectionTestUtils.setField(grand1, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 30));
+        labelRepository.save(grand1);
+
+        Label grand2 = Label.create("grand-2", user, child1);
+        ReflectionTestUtils.setField(grand2, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 40));
+        labelRepository.save(grand2);
+
+        Label grand3 = Label.create("grand-3", user, child2);
+        ReflectionTestUtils.setField(grand3, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 50));
+        labelRepository.save(grand3);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Label> children = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(user.getId(), parent.getId());
+        List<Label> grandChildren = labelRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(user.getId(), parent.getId());
+
+        // then
+        assertThat(children).extracting(Label::getName)
+                .containsExactly("child-2", "child-1");
+        assertThat(grandChildren).extracting(Label::getName)
+                .containsExactly("grand-3", "grand-2", "grand-1");
+    }
+
+    private User createUser() {
+        return User.createSocialUser(
+                "test" + UUID.randomUUID() + "@test.com",
+                "테스트 유저",
+                "profile.png",
+                "google"
+        );
+    }
+}

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -1,0 +1,113 @@
+package org.project.domain.label.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.label.dto.response.LabelHierarchyResponse;
+import org.project.domain.label.dto.response.LabelParentListResponse;
+import org.project.domain.label.entity.Label;
+import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.user.entity.User;
+import org.project.global.exception.domainException.LabelException;
+import org.project.global.exception.errorcode.LabelErrorCode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LabelService 테스트")
+class LabelServiceTest {
+
+    @InjectMocks
+    private LabelServiceImpl labelService;
+
+    @Mock
+    private LabelRepository labelRepository;
+
+    @Test
+    @DisplayName("부모 태그 목록을 조회한다")
+    void getParentLabels_success() {
+        // given
+        User user = createUser();
+        Label parent1 = Label.create("parent-1", user);
+        Label parent2 = Label.create("parent-2", user);
+
+        when(labelRepository.findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of(parent2, parent1));
+
+        // when
+        LabelParentListResponse response = labelService.getParentLabels(1L);
+
+        // then
+        assertThat(response.labels()).hasSize(2);
+        assertThat(response.labels().get(0).name()).isEqualTo("parent-2");
+    }
+
+    @Test
+    @DisplayName("부모 태그 기준 자식과 손자 태그를 트리 구조로 조회한다")
+    void getChildAndGrandChildLabels_success() {
+        // given
+        User user = createUser();
+        Label parent = Label.create("parent", user);
+        Label child1 = Label.create("child-1", user, parent);
+        Label child2 = Label.create("child-2", user, parent);
+        Label grand1 = Label.create("grand-1", user, child1);
+        Label grand2 = Label.create("grand-2", user, child2);
+
+        ReflectionTestUtils.setField(parent, "id", 10L);
+        ReflectionTestUtils.setField(child1, "id", 11L);
+        ReflectionTestUtils.setField(child2, "id", 12L);
+        ReflectionTestUtils.setField(grand1, "id", 21L);
+        ReflectionTestUtils.setField(grand2, "id", 22L);
+
+        when(labelRepository.findByIdAndUserIdAndParentIsNull(10L, 1L))
+                .thenReturn(Optional.of(parent));
+        when(labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 10L))
+                .thenReturn(List.of(child2, child1));
+        when(labelRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(1L, 10L))
+                .thenReturn(List.of(grand2, grand1));
+
+        // when
+        LabelHierarchyResponse response = labelService.getChildAndGrandChildLabels(1L, 10L);
+
+        // then
+        assertThat(response.parentLabel().name()).isEqualTo("parent");
+        assertThat(response.childLabels()).hasSize(2);
+        assertThat(response.childLabels().get(0).name()).isEqualTo("child-2");
+        assertThat(response.childLabels().get(0).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
+                .containsExactly("grand-2");
+        assertThat(response.childLabels().get(1).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
+                .containsExactly("grand-1");
+    }
+
+    @Test
+    @DisplayName("부모 태그가 없으면 예외를 던진다")
+    void getChildAndGrandChildLabels_parentNotFound() {
+        // given
+        when(labelRepository.findByIdAndUserIdAndParentIsNull(10L, 1L))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> labelService.getChildAndGrandChildLabels(1L, 10L))
+                .isInstanceOf(LabelException.class)
+                .hasMessageContaining(LabelErrorCode.PARENT_LABEL_NOT_FOUND.getMsg());
+    }
+
+    private User createUser() {
+        return User.createSocialUser(
+                "test" + UUID.randomUUID() + "@test.com",
+                "테스트 유저",
+                "profile.png",
+                "google"
+        );
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #140

## 📝 Summary

- 부모 태그 전체 조회 API를 추가했습니다.
- 부모 태그 클릭 시 자식 태그와 손자 태그까지 조회할 수 있는 API를 추가했습니다.
- 태그 계층 구조를 위해 `label` 엔티티에 부모-자식 관계를 추가했습니다.
- 부모 태그는 생성일 내림차순 기준 최대 10개만 조회되도록 처리했습니다.

## 🙏 Question & PR point

- 기존 `GET /api/v1/label`은 유지하면서, 계층형 태그 조회용 API를 별도로 추가했습니다.
- 부모 태그 조회 시 `parent is null` 조건으로만 필터링합니다.
- 부모 태그 상세 조회는 부모-자식-손자 구조를 한 번에 내려주도록 구성했습니다.
- 부모 태그가 존재하지 않으면 404 예외를 반환합니다.

## 📬 Postman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 라벨의 계층 구조 조회 기능을 확장했습니다. 사용자 기준 “부모 라벨” 최대 10개를 조회하고, 특정 부모 라벨을 선택하면 자식 및 손자 라벨까지 트리 형태로 함께 조회할 수 있습니다.
  * 계층 조회 응답에 맞춘 라벨 요약/부모 목록/계층 DTO를 추가했습니다.

* **Tests**
  * 라벨 계층 조회 흐름(저장소/서비스) 검증을 위한 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->