### PR TITLE
[FEATURE] 태그 CRUD 및 메모 필터링, 태그 색상 팔레트 적용

### DIFF
--- a/src/main/java/org/project/domain/label/controller/LabelController.java
+++ b/src/main/java/org/project/domain/label/controller/LabelController.java
@@ -2,18 +2,27 @@ package org.project.domain.label.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.project.domain.label.dto.request.LabelCreateRequest;
+import org.project.domain.label.dto.request.LabelUpdateRequest;
 import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelListResponse;
 import org.project.domain.label.dto.response.LabelParentListResponse;
+import org.project.domain.label.dto.response.LabelSummaryResponse;
 import org.project.domain.label.service.LabelService;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,6 +51,64 @@ public class LabelController {
                 labelService.getAllLabels(userId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(
+            summary = "태그 생성",
+            description = """
+            태그를 생성합니다.
+            parentLabelId가 있으면 하위 태그로 생성하고, 없으면 부모 태그로 생성합니다.
+            """
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<LabelSummaryResponse>> createLabel(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody LabelCreateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+
+        LabelSummaryResponse response = labelService.createLabel(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
+    }
+
+    @Operation(
+            summary = "태그 수정",
+            description = """
+            태그 이름을 수정합니다.
+            """
+    )
+    @PutMapping("/{labelId}")
+    public ResponseEntity<ApiResponse<LabelSummaryResponse>> updateLabel(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long labelId,
+            @Valid @RequestBody LabelUpdateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+
+        LabelSummaryResponse response = labelService.updateLabel(userId, labelId, request);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(
+            summary = "태그 삭제",
+            description = """
+            태그를 삭제합니다.
+            태그에 연결된 메모-태그 관계도 함께 정리합니다.
+            """
+    )
+    @DeleteMapping("/{labelId}")
+    public ResponseEntity<ApiResponse<String>> deleteLabel(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long labelId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        labelService.deleteLabel(userId, labelId);
+
+        return ResponseEntity.ok(ApiResponse.ok("태그가 삭제되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/org/project/domain/label/dto/request/LabelCreateRequest.java
+++ b/src/main/java/org/project/domain/label/dto/request/LabelCreateRequest.java
@@ -1,0 +1,14 @@
+package org.project.domain.label.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record LabelCreateRequest(
+        @Schema(description = "태그 이름", example = "SOPT")
+        @NotBlank(message = "태그 이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "부모 태그 ID", example = "1")
+        Long parentLabelId
+) {
+}

--- a/src/main/java/org/project/domain/label/dto/request/LabelUpdateRequest.java
+++ b/src/main/java/org/project/domain/label/dto/request/LabelUpdateRequest.java
@@ -1,0 +1,11 @@
+package org.project.domain.label.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record LabelUpdateRequest(
+        @Schema(description = "태그 이름", example = "SOPT")
+        @NotBlank(message = "태그 이름은 필수입니다.")
+        String name
+) {
+}

--- a/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
@@ -24,16 +24,19 @@ public record LabelHierarchyResponse(
     public record LabelTreeResponse(
             Long labelId,
             String name,
+            String colorHex,
             List<LabelTreeResponse> childLabels
     ) {
         public static LabelTreeResponse from(Label label, List<Label> childLabels) {
             return new LabelTreeResponse(
                     label.getId(),
                     label.getName(),
+                    label.getColorHex(),
                     childLabels.stream()
                             .map(child -> new LabelTreeResponse(
                                     child.getId(),
                                     child.getName(),
+                                    child.getColorHex(),
                                     List.of()
                             ))
                             .toList()

--- a/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
@@ -19,12 +19,14 @@ public record LabelListResponse(
 
     public record LabelResponse(
             Long labelId,
-            String name
+            String name,
+            String colorHex
     ) {
         public static LabelResponse from(Label label) {
             return new LabelResponse(
                     label.getId(),
-                    label.getName()
+                    label.getName(),
+                    label.getColorHex()
             );
         }
     }

--- a/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
@@ -4,12 +4,14 @@ import org.project.domain.label.entity.Label;
 
 public record LabelSummaryResponse(
         Long labelId,
-        String name
+        String name,
+        String colorHex
 ) {
     public static LabelSummaryResponse from(Label label) {
         return new LabelSummaryResponse(
                 label.getId(),
-                label.getName()
+                label.getName(),
+                label.getColorHex()
         );
     }
 }

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -8,6 +8,7 @@ import org.project.global.entity.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Entity
 @Getter
@@ -24,6 +25,9 @@ public class Label extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Column(name = "color_hex", length = 7)
+    private String colorHex;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -44,6 +48,7 @@ public class Label extends BaseEntity {
     public static Label create(String name, User user) {
         return Label.builder()
                 .name(name)
+                .colorHex(generateRandomColorHex())
                 .user(user)
                 .build();
     }
@@ -51,6 +56,7 @@ public class Label extends BaseEntity {
     public static Label create(String name, User user, Label parent) {
         return Label.builder()
                 .name(name)
+                .colorHex(generateRandomColorHex())
                 .user(user)
                 .parent(parent)
                 .build();
@@ -58,6 +64,25 @@ public class Label extends BaseEntity {
 
     public void rename(String name) {
         this.name = name;
+    }
+
+    public String getColorHex() {
+        if (colorHex == null) {
+            colorHex = generateRandomColorHex();
+        }
+        return colorHex;
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void applyColorHex() {
+        if (colorHex == null) {
+            colorHex = generateRandomColorHex();
+        }
+    }
+
+    private static String generateRandomColorHex() {
+        return String.format("#%06X", ThreadLocalRandom.current().nextInt(0x1000000));
     }
 
     /**

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -56,6 +56,10 @@ public class Label extends BaseEntity {
                 .build();
     }
 
+    public void rename(String name) {
+        this.name = name;
+    }
+
     /**
      * 기본 라벨 목록 생성
      * - 최초 회원가입 시 사용

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -18,6 +18,14 @@ import java.util.concurrent.ThreadLocalRandom;
 @Table(name = "label")
 public class Label extends BaseEntity {
 
+    private static final List<String> COLOR_PALETTE = List.of(
+            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
+            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
+            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
+            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
+            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
+    );
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "label_id")
@@ -82,7 +90,7 @@ public class Label extends BaseEntity {
     }
 
     private static String generateRandomColorHex() {
-        return String.format("#%06X", ThreadLocalRandom.current().nextInt(0x1000000));
+        return COLOR_PALETTE.get(ThreadLocalRandom.current().nextInt(COLOR_PALETTE.size()));
     }
 
     /**

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -15,7 +15,10 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "label")
+@Table(
+        name = "label",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "name"})
+)
 public class Label extends BaseEntity {
 
     @Id
@@ -26,7 +29,7 @@ public class Label extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "color_hex", length = 7)
+    @Column(name = "color_hex", nullable = false, length = 7)
     private String colorHex;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -67,9 +70,6 @@ public class Label extends BaseEntity {
     }
 
     public String getColorHex() {
-        if (colorHex == null) {
-            colorHex = LabelColorPalette.randomColor();
-        }
         return colorHex;
     }
 

--- a/src/main/java/org/project/domain/label/entity/Label.java
+++ b/src/main/java/org/project/domain/label/entity/Label.java
@@ -2,13 +2,13 @@ package org.project.domain.label.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.project.domain.label.util.LabelColorPalette;
 import org.project.domain.memo.entity.MemoLabel;
 import org.project.domain.user.entity.User;
 import org.project.global.entity.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 @Entity
 @Getter
@@ -17,14 +17,6 @@ import java.util.concurrent.ThreadLocalRandom;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "label")
 public class Label extends BaseEntity {
-
-    private static final List<String> COLOR_PALETTE = List.of(
-            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
-            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
-            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
-            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
-            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
-    );
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,7 +48,7 @@ public class Label extends BaseEntity {
     public static Label create(String name, User user) {
         return Label.builder()
                 .name(name)
-                .colorHex(generateRandomColorHex())
+                .colorHex(LabelColorPalette.randomColor())
                 .user(user)
                 .build();
     }
@@ -64,7 +56,7 @@ public class Label extends BaseEntity {
     public static Label create(String name, User user, Label parent) {
         return Label.builder()
                 .name(name)
-                .colorHex(generateRandomColorHex())
+                .colorHex(LabelColorPalette.randomColor())
                 .user(user)
                 .parent(parent)
                 .build();
@@ -76,7 +68,7 @@ public class Label extends BaseEntity {
 
     public String getColorHex() {
         if (colorHex == null) {
-            colorHex = generateRandomColorHex();
+            colorHex = LabelColorPalette.randomColor();
         }
         return colorHex;
     }
@@ -85,12 +77,8 @@ public class Label extends BaseEntity {
     @PreUpdate
     private void applyColorHex() {
         if (colorHex == null) {
-            colorHex = generateRandomColorHex();
+            colorHex = LabelColorPalette.randomColor();
         }
-    }
-
-    private static String generateRandomColorHex() {
-        return COLOR_PALETTE.get(ThreadLocalRandom.current().nextInt(COLOR_PALETTE.size()));
     }
 
     /**

--- a/src/main/java/org/project/domain/label/repository/LabelRepository.java
+++ b/src/main/java/org/project/domain/label/repository/LabelRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 public interface LabelRepository extends JpaRepository<Label, Long> {
     Optional<Label> findByNameAndUser(String name, User user);
 
+    Optional<Label> findByNameAndUserId(String name, Long userId);
+
     List<Label> findAllByUserId(Long userId);
+
+    Optional<Label> findByIdAndUserId(Long id, Long userId);
 
     List<Label> findTop10ByUserIdAndParentIsNullOrderByCreatedAtDesc(Long userId);
 

--- a/src/main/java/org/project/domain/label/service/LabelService.java
+++ b/src/main/java/org/project/domain/label/service/LabelService.java
@@ -1,8 +1,11 @@
 package org.project.domain.label.service;
 
+import org.project.domain.label.dto.request.LabelCreateRequest;
+import org.project.domain.label.dto.request.LabelUpdateRequest;
 import org.project.domain.label.dto.response.LabelListResponse;
 import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelParentListResponse;
+import org.project.domain.label.dto.response.LabelSummaryResponse;
 
 public interface LabelService {
 
@@ -11,4 +14,10 @@ public interface LabelService {
     LabelParentListResponse getParentLabels(Long userId);
 
     LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentLabelId);
+
+    LabelSummaryResponse createLabel(Long userId, LabelCreateRequest request);
+
+    LabelSummaryResponse updateLabel(Long userId, Long labelId, LabelUpdateRequest request);
+
+    void deleteLabel(Long userId, Long labelId);
 }

--- a/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
+++ b/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
@@ -1,11 +1,17 @@
 package org.project.domain.label.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.domain.label.dto.request.LabelCreateRequest;
+import org.project.domain.label.dto.request.LabelUpdateRequest;
 import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelListResponse;
 import org.project.domain.label.dto.response.LabelParentListResponse;
+import org.project.domain.label.dto.response.LabelSummaryResponse;
 import org.project.domain.label.entity.Label;
 import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.memo.repository.MemoLabelRepository;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.LabelException;
 import org.project.global.exception.errorcode.LabelErrorCode;
 import org.springframework.stereotype.Service;
@@ -13,7 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +29,8 @@ import java.util.stream.Collectors;
 public class LabelServiceImpl implements LabelService{
 
     private final LabelRepository labelRepository;
+    private final MemoLabelRepository memoLabelRepository;
+    private final UserRepository userRepository;
 
     public LabelListResponse getAllLabels(Long userId) {
         List<Label> labels = labelRepository.findAllByUserId(userId);
@@ -45,5 +55,90 @@ public class LabelServiceImpl implements LabelService{
                 .collect(Collectors.groupingBy(label -> label.getParent().getId()));
 
         return LabelHierarchyResponse.from(parentLabel, childLabels, grandChildLabelsByParentId);
+    }
+
+    @Override
+    @Transactional
+    public LabelSummaryResponse createLabel(Long userId, LabelCreateRequest request) {
+        return createLabelInternal(userId, request);
+    }
+
+    private LabelSummaryResponse createLabelInternal(Long userId, LabelCreateRequest request) {
+        Label parentLabel = null;
+
+        if (request.parentLabelId() != null) {
+            parentLabel = getLabelOrThrow(userId, request.parentLabelId());
+            validateLabelDepth(parentLabel);
+        }
+
+        ensureLabelNameIsUnique(userId, request.name(), null);
+
+        User user = getUserOrThrow(userId);
+
+        Label label = parentLabel == null
+                ? Label.create(request.name(), user)
+                : Label.create(request.name(), user, parentLabel);
+
+        Label savedLabel = labelRepository.save(label);
+        return LabelSummaryResponse.from(savedLabel);
+    }
+
+    @Override
+    @Transactional
+    public LabelSummaryResponse updateLabel(Long userId, Long labelId, LabelUpdateRequest request) {
+        Label label = getLabelOrThrow(userId, labelId);
+        ensureLabelNameIsUnique(userId, request.name(), labelId);
+
+        label.rename(request.name());
+        return LabelSummaryResponse.from(label);
+    }
+
+    @Override
+    @Transactional
+    public void deleteLabel(Long userId, Long labelId) {
+        Label target = getLabelOrThrow(userId, labelId);
+
+        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, labelId);
+        List<Label> grandChildLabels = new ArrayList<>();
+        for (Label child : childLabels) {
+            grandChildLabels.addAll(labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, child.getId()));
+        }
+
+        List<Long> labelIds = new ArrayList<>();
+        grandChildLabels.forEach(label -> labelIds.add(label.getId()));
+        childLabels.forEach(label -> labelIds.add(label.getId()));
+        labelIds.add(target.getId());
+
+        if (!labelIds.isEmpty()) {
+            memoLabelRepository.deleteByLabelIds(labelIds);
+        }
+
+        grandChildLabels.forEach(labelRepository::delete);
+        childLabels.forEach(labelRepository::delete);
+        labelRepository.delete(target);
+    }
+
+    private Label getLabelOrThrow(Long userId, Long labelId) {
+        return labelRepository.findByIdAndUserId(labelId, userId)
+                .orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
+    }
+
+    private void ensureLabelNameIsUnique(Long userId, String name, Long currentLabelId) {
+        Optional<Label> optionalLabel = labelRepository.findByNameAndUserId(name, userId);
+
+        if (optionalLabel.isPresent() && !optionalLabel.get().getId().equals(currentLabelId)) {
+            throw new LabelException(LabelErrorCode.LABEL_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateLabelDepth(Label parentLabel) {
+        if (parentLabel.getParent() != null && parentLabel.getParent().getParent() != null) {
+            throw new LabelException(LabelErrorCode.LABEL_DEPTH_LIMIT_EXCEEDED);
+        }
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
     }
 }

--- a/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
+++ b/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
@@ -13,7 +13,9 @@ import org.project.domain.memo.repository.MemoLabelRepository;
 import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.LabelException;
+import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.LabelErrorCode;
+import org.project.global.exception.errorcode.UserErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,6 +69,7 @@ public class LabelServiceImpl implements LabelService{
         Label parentLabel = null;
 
         if (request.parentLabelId() != null) {
+            validateParentLabelId(request.parentLabelId());
             parentLabel = getLabelOrThrow(userId, request.parentLabelId());
             validateLabelDepth(parentLabel);
         }
@@ -137,8 +140,14 @@ public class LabelServiceImpl implements LabelService{
         }
     }
 
+    private void validateParentLabelId(Long parentLabelId) {
+        if (parentLabelId <= 0) {
+            throw new LabelException(LabelErrorCode.INVALID_PARENT_LABEL_ID);
+        }
+    }
+
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new LabelException(LabelErrorCode.LABEL_NOT_FOUND));
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
     }
 }

--- a/src/main/java/org/project/domain/label/util/LabelColorPalette.java
+++ b/src/main/java/org/project/domain/label/util/LabelColorPalette.java
@@ -1,0 +1,26 @@
+package org.project.domain.label.util;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class LabelColorPalette {
+
+    private static final List<String> COLORS = List.of(
+            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
+            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
+            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
+            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
+            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
+    );
+
+    private LabelColorPalette() {
+    }
+
+    public static String randomColor() {
+        return COLORS.get(ThreadLocalRandom.current().nextInt(COLORS.size()));
+    }
+
+    public static List<String> colors() {
+        return COLORS;
+    }
+}

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -76,13 +76,15 @@ public record MemoListDashboardResponse(
      */
     public record LabelResponse(
             Long labelId,
-            String name
+            String name,
+            String colorHex
     ) {
 
         public static LabelResponse from(Label label) {
             return new LabelResponse(
                     label.getId(),
-                    label.getName()
+                    label.getName(),
+                    label.getColorHex()
             );
         }
     }

--- a/src/main/java/org/project/domain/memo/repository/MemoLabelRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoLabelRepository.java
@@ -7,9 +7,15 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MemoLabelRepository extends JpaRepository<MemoLabel, Long> {
 
     @Modifying
     @Query("DELETE FROM MemoLabel ml WHERE ml.memo = :memo")
     void deleteByMemo(@Param("memo") Memo memo);
+
+    @Modifying
+    @Query("DELETE FROM MemoLabel ml WHERE ml.label.id IN :labelIds")
+    void deleteByLabelIds(@Param("labelIds") List<Long> labelIds);
 }

--- a/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
@@ -9,7 +9,8 @@ public enum LabelErrorCode implements ErrorCode {
     LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "태그를 찾을 수 없습니다."),
     PARENT_LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "부모 태그를 찾을 수 없습니다."),
     LABEL_ALREADY_EXISTS(HttpStatus.CONFLICT, 409, "이미 존재하는 태그명입니다."),
-    LABEL_DEPTH_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 400, "태그는 최대 3단계까지만 생성할 수 있습니다.");
+    LABEL_DEPTH_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 400, "태그는 최대 3단계까지만 생성할 수 있습니다."),
+    INVALID_PARENT_LABEL_ID(HttpStatus.BAD_REQUEST, 400, "부모 태그 ID는 1 이상이어야 합니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/LabelErrorCode.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum LabelErrorCode implements ErrorCode {
 
-    PARENT_LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "부모 태그를 찾을 수 없습니다.");
+    LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "태그를 찾을 수 없습니다."),
+    PARENT_LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "부모 태그를 찾을 수 없습니다."),
+    LABEL_ALREADY_EXISTS(HttpStatus.CONFLICT, 409, "이미 존재하는 태그명입니다."),
+    LABEL_DEPTH_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 400, "태그는 최대 3단계까지만 생성할 수 있습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -65,6 +65,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labels()).hasSize(2);
         assertThat(response.labels().get(0).name()).isEqualTo("parent-2");
+        assertThat(response.labels().get(0).colorHex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test
@@ -96,8 +97,10 @@ class LabelServiceTest {
 
         // then
         assertThat(response.parentLabel().name()).isEqualTo("parent");
+        assertThat(response.parentLabel().colorHex()).matches("^#[0-9A-F]{6}$");
         assertThat(response.childLabels()).hasSize(2);
         assertThat(response.childLabels().get(0).name()).isEqualTo("child-2");
+        assertThat(response.childLabels().get(0).colorHex()).matches("^#[0-9A-F]{6}$");
         assertThat(response.childLabels().get(0).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
                 .containsExactly("grand-2");
         assertThat(response.childLabels().get(1).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
@@ -134,6 +137,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
+        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test
@@ -158,6 +162,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
+        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test
@@ -177,6 +182,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
+        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
     }
 
     @Test

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -13,6 +13,7 @@ import org.project.domain.label.dto.response.LabelParentListResponse;
 import org.project.domain.label.dto.response.LabelSummaryResponse;
 import org.project.domain.label.entity.Label;
 import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.label.util.LabelColorPalette;
 import org.project.domain.memo.repository.MemoLabelRepository;
 import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
@@ -35,14 +36,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LabelService 테스트")
 class LabelServiceTest {
-
-    private static final List<String> COLOR_PALETTE = List.of(
-            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
-            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
-            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
-            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
-            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
-    );
 
     @InjectMocks
     private LabelServiceImpl labelService;
@@ -73,7 +66,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labels()).hasSize(2);
         assertThat(response.labels().get(0).name()).isEqualTo("parent-2");
-        assertThat(response.labels().get(0).colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.labels().get(0).colorHex()).isIn(LabelColorPalette.colors());
     }
 
     @Test
@@ -105,10 +98,10 @@ class LabelServiceTest {
 
         // then
         assertThat(response.parentLabel().name()).isEqualTo("parent");
-        assertThat(response.parentLabel().colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.parentLabel().colorHex()).isIn(LabelColorPalette.colors());
         assertThat(response.childLabels()).hasSize(2);
         assertThat(response.childLabels().get(0).name()).isEqualTo("child-2");
-        assertThat(response.childLabels().get(0).colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.childLabels().get(0).colorHex()).isIn(LabelColorPalette.colors());
         assertThat(response.childLabels().get(0).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
                 .containsExactly("grand-2");
         assertThat(response.childLabels().get(1).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
@@ -145,7 +138,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
-        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
     }
 
     @Test
@@ -170,7 +163,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
-        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
     }
 
     @Test
@@ -190,7 +183,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
-        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
+        assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
     }
 
     @Test

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -18,7 +18,9 @@ import org.project.domain.memo.repository.MemoLabelRepository;
 import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.LabelException;
+import org.project.global.exception.domainException.UserException;
 import org.project.global.exception.errorcode.LabelErrorCode;
+import org.project.global.exception.errorcode.UserErrorCode;
 
 import java.util.List;
 import java.util.Optional;
@@ -226,6 +228,27 @@ class LabelServiceTest {
         assertThatThrownBy(() -> labelService.createLabel(1L, new LabelCreateRequest("parent", null)))
                 .isInstanceOf(LabelException.class)
                 .hasMessageContaining(LabelErrorCode.LABEL_ALREADY_EXISTS.getMsg());
+    }
+
+    @Test
+    @DisplayName("사용자가 없으면 사용자 예외를 던진다")
+    void createLabel_userNotFound_fail() {
+        // given
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> labelService.createLabel(1L, new LabelCreateRequest("parent", null)))
+                .isInstanceOf(UserException.class)
+                .hasMessageContaining(UserErrorCode.NOT_FOUND_USER.getMsg());
+    }
+
+    @Test
+    @DisplayName("부모 태그 ID가 0 이하이면 예외를 던진다")
+    void createLabel_invalidParentId_fail() {
+        // when & then
+        assertThatThrownBy(() -> labelService.createLabel(1L, new LabelCreateRequest("child", 0L)))
+                .isInstanceOf(LabelException.class)
+                .hasMessageContaining(LabelErrorCode.INVALID_PARENT_LABEL_ID.getMsg());
     }
 
     private User createUser() {

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -6,11 +6,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.label.dto.request.LabelCreateRequest;
+import org.project.domain.label.dto.request.LabelUpdateRequest;
 import org.project.domain.label.dto.response.LabelHierarchyResponse;
 import org.project.domain.label.dto.response.LabelParentListResponse;
+import org.project.domain.label.dto.response.LabelSummaryResponse;
 import org.project.domain.label.entity.Label;
 import org.project.domain.label.repository.LabelRepository;
+import org.project.domain.memo.repository.MemoLabelRepository;
 import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.LabelException;
 import org.project.global.exception.errorcode.LabelErrorCode;
 
@@ -20,8 +25,12 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 import org.springframework.test.util.ReflectionTestUtils;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LabelService 테스트")
@@ -32,6 +41,12 @@ class LabelServiceTest {
 
     @Mock
     private LabelRepository labelRepository;
+
+    @Mock
+    private MemoLabelRepository memoLabelRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("부모 태그 목록을 조회한다")
@@ -100,6 +115,110 @@ class LabelServiceTest {
         assertThatThrownBy(() -> labelService.getChildAndGrandChildLabels(1L, 10L))
                 .isInstanceOf(LabelException.class)
                 .hasMessageContaining(LabelErrorCode.PARENT_LABEL_NOT_FOUND.getMsg());
+    }
+
+    @Test
+    @DisplayName("부모 태그를 생성한다")
+    void createLabel_parent_success() {
+        // given
+        User user = createUser();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(labelRepository.findByNameAndUserId("parent", 1L)).thenReturn(Optional.empty());
+        Label saved = Label.create("parent", user);
+        ReflectionTestUtils.setField(saved, "id", 100L);
+        when(labelRepository.save(any(Label.class))).thenReturn(saved);
+
+        // when
+        LabelSummaryResponse response = labelService.createLabel(1L, new LabelCreateRequest("parent", null));
+
+        // then
+        assertThat(response.labelId()).isEqualTo(100L);
+        assertThat(response.name()).isEqualTo("parent");
+    }
+
+    @Test
+    @DisplayName("자식 태그를 생성한다")
+    void createLabel_child_success() {
+        // given
+        User user = createUser();
+        Label parent = Label.create("parent", user);
+        ReflectionTestUtils.setField(parent, "id", 10L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(labelRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(parent));
+        when(labelRepository.findByNameAndUserId("child", 1L)).thenReturn(Optional.empty());
+
+        Label saved = Label.create("child", user, parent);
+        ReflectionTestUtils.setField(saved, "id", 101L);
+        when(labelRepository.save(any(Label.class))).thenReturn(saved);
+
+        // when
+        LabelSummaryResponse response = labelService.createLabel(1L, new LabelCreateRequest("child", 10L));
+
+        // then
+        assertThat(response.labelId()).isEqualTo(101L);
+        assertThat(response.name()).isEqualTo("child");
+    }
+
+    @Test
+    @DisplayName("태그 이름을 수정한다")
+    void updateLabel_success() {
+        // given
+        User user = createUser();
+        Label label = Label.create("old", user);
+        ReflectionTestUtils.setField(label, "id", 10L);
+
+        when(labelRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(label));
+        when(labelRepository.findByNameAndUserId("new", 1L)).thenReturn(Optional.empty());
+
+        // when
+        LabelSummaryResponse response = labelService.updateLabel(1L, 10L, new LabelUpdateRequest("new"));
+
+        // then
+        assertThat(response.labelId()).isEqualTo(10L);
+        assertThat(response.name()).isEqualTo("new");
+    }
+
+    @Test
+    @DisplayName("태그를 삭제하면 연관 메모 태그도 삭제한다")
+    void deleteLabel_success() {
+        // given
+        User user = createUser();
+        Label parent = Label.create("parent", user);
+        ReflectionTestUtils.setField(parent, "id", 10L);
+
+        Label child = Label.create("child", user, parent);
+        ReflectionTestUtils.setField(child, "id", 11L);
+
+        when(labelRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(parent));
+        when(labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 10L))
+                .thenReturn(List.of(child));
+        when(labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 11L))
+                .thenReturn(List.of());
+
+        // when
+        labelService.deleteLabel(1L, 10L);
+
+        // then
+        verify(memoLabelRepository).deleteByLabelIds(List.of(11L, 10L));
+        verify(labelRepository).delete(child);
+        verify(labelRepository).delete(parent);
+    }
+
+    @Test
+    @DisplayName("중복된 태그 이름이면 예외를 던진다")
+    void createLabel_duplicateName_fail() {
+        // given
+        User user = createUser();
+        Label existing = Label.create("parent", user);
+        ReflectionTestUtils.setField(existing, "id", 10L);
+
+        when(labelRepository.findByNameAndUserId("parent", 1L)).thenReturn(Optional.of(existing));
+
+        // when & then
+        assertThatThrownBy(() -> labelService.createLabel(1L, new LabelCreateRequest("parent", null)))
+                .isInstanceOf(LabelException.class)
+                .hasMessageContaining(LabelErrorCode.LABEL_ALREADY_EXISTS.getMsg());
     }
 
     private User createUser() {

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -36,6 +36,14 @@ import static org.mockito.Mockito.when;
 @DisplayName("LabelService 테스트")
 class LabelServiceTest {
 
+    private static final List<String> COLOR_PALETTE = List.of(
+            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
+            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
+            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
+            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
+            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
+    );
+
     @InjectMocks
     private LabelServiceImpl labelService;
 
@@ -65,7 +73,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labels()).hasSize(2);
         assertThat(response.labels().get(0).name()).isEqualTo("parent-2");
-        assertThat(response.labels().get(0).colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.labels().get(0).colorHex()).isIn(COLOR_PALETTE);
     }
 
     @Test
@@ -97,10 +105,10 @@ class LabelServiceTest {
 
         // then
         assertThat(response.parentLabel().name()).isEqualTo("parent");
-        assertThat(response.parentLabel().colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.parentLabel().colorHex()).isIn(COLOR_PALETTE);
         assertThat(response.childLabels()).hasSize(2);
         assertThat(response.childLabels().get(0).name()).isEqualTo("child-2");
-        assertThat(response.childLabels().get(0).colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.childLabels().get(0).colorHex()).isIn(COLOR_PALETTE);
         assertThat(response.childLabels().get(0).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
                 .containsExactly("grand-2");
         assertThat(response.childLabels().get(1).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
@@ -137,7 +145,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
-        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
     }
 
     @Test
@@ -162,7 +170,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
-        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
     }
 
     @Test
@@ -182,7 +190,7 @@ class LabelServiceTest {
         // then
         assertThat(response.labelId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
-        assertThat(response.colorHex()).matches("^#[0-9A-F]{6}$");
+        assertThat(response.colorHex()).isIn(COLOR_PALETTE);
     }
 
     @Test

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -849,6 +849,12 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.memos[0].fileCount").value(1))
                     .andExpect(jsonPath("$.data.memos[0].isPinned").value(false))
                     .andExpect(jsonPath("$.data.memos[0].labelList.length()").value(2))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].labelId").value(1L))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].name").value("SOPT"))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].colorHex").value("#FF5722"))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[1].labelId").value(2L))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[1].name").value("교양"))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[1].colorHex").value("#4CAF50"))
                     .andExpect(jsonPath("$.data.memos[1].memoId").value(2L))
                     .andExpect(jsonPath("$.data.memos[1].isPinned").value(true));
 
@@ -900,7 +906,8 @@ class MemoControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.memos.length()").value(1))
                     .andExpect(jsonPath("$.data.memos[0].labelList[0].labelId").value(1L))
-                    .andExpect(jsonPath("$.data.memos[0].labelList[0].name").value("SOPT"));
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].name").value("SOPT"))
+                    .andExpect(jsonPath("$.data.memos[0].labelList[0].colorHex").value("#FF5722"));
 
             verify(memoService, times(1))
                     .getMemosWithMedia(eq(userId), eq(labelIds), eq(null), eq(null), eq(20));
@@ -1079,6 +1086,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.labelList.length()").value(3))
                     .andExpect(jsonPath("$.data.labelList[0].labelId").value(1L))
                     .andExpect(jsonPath("$.data.labelList[0].name").value("SOPT"))
+                    .andExpect(jsonPath("$.data.labelList[0].colorHex").value("#FF5722"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
@@ -1116,6 +1124,9 @@ class MemoControllerTest {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
+                    .andExpect(jsonPath("$.data.labelList[0].labelId").value(1L))
+                    .andExpect(jsonPath("$.data.labelList[0].name").value("개인"))
+                    .andExpect(jsonPath("$.data.labelList[0].colorHex").value("#9C27B0"))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
 
@@ -1155,7 +1166,10 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.images").isArray())
                     .andExpect(jsonPath("$.data.images.length()").value(0))
                     .andExpect(jsonPath("$.data.files").isArray())
-                    .andExpect(jsonPath("$.data.files.length()").value(0));
+                    .andExpect(jsonPath("$.data.files.length()").value(0))
+                    .andExpect(jsonPath("$.data.labelList[0].labelId").value(1L))
+                    .andExpect(jsonPath("$.data.labelList[0].name").value("메모"))
+                    .andExpect(jsonPath("$.data.labelList[0].colorHex").value("#795548"));
 
             verify(memoService, times(1))
                     .getOneMemoDetail(eq(userId), eq(memoId));

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -804,8 +804,8 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT"),
-                                    new MemoListDashboardResponse.LabelResponse(2L, "교양")
+                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT", "#FF5722"),
+                                    new MemoListDashboardResponse.LabelResponse(2L, "교양", "#4CAF50")
                             )
                     );
 
@@ -877,7 +877,7 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT")
+                                    new MemoListDashboardResponse.LabelResponse(1L, "SOPT", "#FF5722")
                             )
                     );
 
@@ -1045,9 +1045,9 @@ class MemoControllerTest {
                     List.of(image1, image2),
                     List.of(file),
                     List.of(
-                            new MemoListDashboardResponse.LabelResponse(1L, "SOPT"),
-                            new MemoListDashboardResponse.LabelResponse(2L, "교양"),
-                            new MemoListDashboardResponse.LabelResponse(3L, "레퍼런스")
+                            new MemoListDashboardResponse.LabelResponse(1L, "SOPT", "#FF5722"),
+                            new MemoListDashboardResponse.LabelResponse(2L, "교양", "#4CAF50"),
+                            new MemoListDashboardResponse.LabelResponse(3L, "레퍼런스", "#2196F3")
                     ),
                     LocalDateTime.of(2026, 1, 16, 10, 30),
                     false,  // AI 생성 아님
@@ -1101,7 +1101,7 @@ class MemoControllerTest {
                     "사용자가 직접 작성한 메모입니다.",
                     List.of(),
                     List.of(),
-                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "개인")),
+                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "개인", "#9C27B0")),
                     LocalDateTime.of(2026, 1, 16, 12, 0),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
@@ -1137,7 +1137,7 @@ class MemoControllerTest {
                     "이미지나 파일 없이 텍스트만 있습니다.",
                     List.of(),  // 이미지 없음
                     List.of(),  // 파일 없음
-                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "메모")),
+                    List.of(new MemoListDashboardResponse.LabelResponse(1L, "메모", "#795548")),
                     LocalDateTime.of(2026, 1, 16, 13, 0),
                     false,
                     List.of()


### PR DESCRIPTION
## 📣 Related Issue

- close #142

## 📝 Summary

- 태그 CRUD API를 추가했습니다.
- 태그로 메모를 필터링하여 전체 조회하는 기능은 기존 `GET /api/v1/memo?labelIds=...` 을 사용합니다.
- 태그 생성 시 서버에서 랜덤 색상 hex를 저장하도록 추가했습니다.
- 태그 조회 시 색상 hex를 함께 응답하도록 변경했습니다.
- 색상 팔레트는 별도 유틸 클래스로 분리해 25개 고정 팔레트 중 랜덤 선택하도록 했습니다.

## 🙏 Question & PR point

- 태그 응답에는 `labelId`, `name`, `colorHex`가 포함됩니다.
- 부모 태그는 생성일 내림차순으로 최대 10개만 조회됩니다.
- 태그 생성 시 색상은 `LabelColorPalette`에서 관리하는 25개 팔레트 중 하나를 랜덤 선택합니다.
- 메모 조회 응답의 라벨 정보에도 `colorHex`를 함께 내려서 프론트에서 즉시 색상을 사용할 수 있도록 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 라벨 생성, 수정, 삭제 API 엔드포인트 추가
  * 라벨 생성 시 자동 색상 할당 기능
  * 라벨 계층 깊이 최대 3단계 제한 검증

* **Bug Fixes**
  * 라벨 중복 이름 검증 추가
  * 라벨 삭제 시 관련 메모 라벨 자동 정리

* **Style**
  * 라벨 응답에 색상 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->