### PR TITLE
[FIX] Google OAuth 콜백에서 code 재전달 후 로그인 처리 분리

### DIFF
--- a/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
+++ b/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
@@ -63,8 +63,9 @@ public class GoogleOAuthController {
                     "프론트엔드의 콜백 URL로 code만 전달해 리다이렉트합니다.")
     @GetMapping("/oauth/google/callback")
     @BusinessExceptionDescription(SwaggerResponseDescription.GOOGLE_LOGIN_CALLBACK)
-    public ResponseEntity<Void> callback(
+    public ResponseEntity<?> callback(
             @RequestParam Map<String, String> params,
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
         String code = params.get("code");
@@ -73,7 +74,9 @@ public class GoogleOAuthController {
             throw new LoginException(LoginErrorCode.AUTH_SOCIAL_LOGIN_FAIL);
         }
 
-        googleAuthService.loginOrRegisterWithResponse(code, response);
+        if (isFrontendLoginRequest(request)) {
+            return googleAuthService.loginOrRegisterWithResponse(code, response);
+        }
 
         URI redirectUri = UriComponentsBuilder
                 .fromUriString(frontendCallbackUrl)
@@ -84,6 +87,26 @@ public class GoogleOAuthController {
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(redirectUri)
                 .build();
+    }
+
+    private boolean isFrontendLoginRequest(HttpServletRequest request) {
+        String frontendOrigin = extractOrigin(frontendCallbackUrl);
+        String origin = request.getHeader("Origin");
+        if (origin != null && origin.equals(frontendOrigin)) {
+            return true;
+        }
+
+        String referer = request.getHeader("Referer");
+        return referer != null && referer.startsWith(frontendOrigin);
+    }
+
+    private String extractOrigin(String url) {
+        try {
+            URI uri = URI.create(url);
+            return uri.getScheme() + "://" + uri.getAuthority();
+        } catch (Exception e) {
+            throw new IllegalStateException("frontend-callback-url 설정값이 올바르지 않습니다.", e);
+        }
     }
 
     @Operation(summary = "로그아웃 API")

--- a/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
+++ b/src/main/java/org/project/domain/user/controller/GoogleOAuthController.java
@@ -97,7 +97,7 @@ public class GoogleOAuthController {
         }
 
         String referer = request.getHeader("Referer");
-        return referer != null && referer.startsWith(frontendOrigin);
+        return referer != null && frontendOrigin.equals(extractOrigin(referer));
     }
 
     private String extractOrigin(String url) {

--- a/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
+++ b/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -42,14 +43,26 @@ class GoogleOAuthControllerTest {
     @Test
     @DisplayName("Google 콜백은 code만 프론트 callback으로 전달한다")
     void callback_redirects_only_code() throws Exception {
-        when(googleAuthService.loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class)))
-                .thenReturn(ResponseEntity.ok(ApiResponse.ok(null)));
 
         mockMvc.perform(get("/oauth/google/callback")
                         .queryParam("iss", "https://accounts.google.com")
                         .queryParam("code", "abc123"))
                 .andExpect(status().isFound())
                 .andExpect(header().string("Location", "http://localhost:5173/oauth/callback?code=abc123"));
+
+        verify(googleAuthService, never()).loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("프론트에서 전달한 code는 백엔드 로그인 처리에 사용한다")
+    void callback_processes_frontend_login_request() throws Exception {
+        when(googleAuthService.loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class)))
+                .thenReturn(ResponseEntity.ok(ApiResponse.ok(null)));
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .queryParam("code", "abc123")
+                        .header("Origin", "http://localhost:5173"))
+                .andExpect(status().isOk());
 
         verify(googleAuthService).loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class));
     }

--- a/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
+++ b/src/test/java/org/project/domain/user/controller/GoogleOAuthControllerTest.java
@@ -66,4 +66,16 @@ class GoogleOAuthControllerTest {
 
         verify(googleAuthService).loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class));
     }
+
+    @Test
+    @DisplayName("악성 Referer는 프론트 요청으로 인정하지 않는다")
+    void callback_does_not_accept_spoofed_referer() throws Exception {
+        mockMvc.perform(get("/oauth/google/callback")
+                        .queryParam("code", "abc123")
+                        .header("Referer", "http://localhost:5173.evil.com/oauth/callback"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "http://localhost:5173/oauth/callback?code=abc123"));
+
+        verify(googleAuthService, never()).loginOrRegisterWithResponse(eq("abc123"), any(HttpServletResponse.class));
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #146 

## 📝 Summary

- `GET /oauth/google`는 기존처럼 구글 로그인 페이지로 리다이렉트하도록 유지
- `GET /oauth/google/callback`의 역할을 분리
  - Google에서 처음 들어오는 콜백 요청은 `code`만 프론트 콜백 URL로 전달
  - 프론트가 다시 전달한 `code` 요청은 백엔드에서 Google 토큰 교환 및 로그인 처리 수행

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Google OAuth 로그인 콜백 처리가 개선되었습니다. 요청 출처를 감지하여 프론트엔드 로그인 요청과 리다이렉트를 구분 처리하도록 변경되었습니다.

* **테스트**
  * Google OAuth 콜백 처리에 대한 테스트 커버리지가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->