### PR TITLE
[FIX] tag 네이밍 변경 및 parentId 응답 추가

### DIFF
--- a/src/main/java/org/project/domain/label/controller/LabelController.java
+++ b/src/main/java/org/project/domain/label/controller/LabelController.java
@@ -27,8 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/label")
-@Tag(name = "라벨", description = "라벨 관련 API")
+@RequestMapping("/api/v1/tag")
+@Tag(name = "태그", description = "태그 관련 API")
 public class LabelController {
 
     private final LabelService labelService;
@@ -57,7 +57,7 @@ public class LabelController {
             summary = "태그 생성",
             description = """
             태그를 생성합니다.
-            parentLabelId가 있으면 하위 태그로 생성하고, 없으면 부모 태그로 생성합니다.
+            parentTagId가 있으면 하위 태그로 생성하고, 없으면 부모 태그로 생성합니다.
             """
     )
     @PostMapping
@@ -79,15 +79,15 @@ public class LabelController {
             태그 이름을 수정합니다.
             """
     )
-    @PutMapping("/{labelId}")
+    @PutMapping("/{tagId}")
     public ResponseEntity<ApiResponse<LabelSummaryResponse>> updateLabel(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long labelId,
+            @PathVariable Long tagId,
             @Valid @RequestBody LabelUpdateRequest request
     ) {
         Long userId = userDetails.getUserId();
 
-        LabelSummaryResponse response = labelService.updateLabel(userId, labelId, request);
+        LabelSummaryResponse response = labelService.updateLabel(userId, tagId, request);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
@@ -99,14 +99,14 @@ public class LabelController {
             태그에 연결된 메모-태그 관계도 함께 정리합니다.
             """
     )
-    @DeleteMapping("/{labelId}")
+    @DeleteMapping("/{tagId}")
     public ResponseEntity<ApiResponse<String>> deleteLabel(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long labelId
+            @PathVariable Long tagId
     ) {
         Long userId = userDetails.getUserId();
 
-        labelService.deleteLabel(userId, labelId);
+        labelService.deleteLabel(userId, tagId);
 
         return ResponseEntity.ok(ApiResponse.ok("태그가 삭제되었습니다."));
     }
@@ -134,14 +134,14 @@ public class LabelController {
             부모 태그를 기준으로 자식 태그와 손자 태그를 계층 구조로 조회합니다.
             """
     )
-    @GetMapping("/parents/{parentLabelId}/children")
+    @GetMapping("/parents/{parentTagId}/children")
     public ResponseEntity<ApiResponse<LabelHierarchyResponse>> getChildAndGrandChildLabels(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long parentLabelId
+            @PathVariable Long parentTagId
     ) {
         Long userId = userDetails.getUserId();
 
-        LabelHierarchyResponse response = labelService.getChildAndGrandChildLabels(userId, parentLabelId);
+        LabelHierarchyResponse response = labelService.getChildAndGrandChildLabels(userId, parentTagId);
 
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/src/main/java/org/project/domain/label/dto/request/LabelCreateRequest.java
+++ b/src/main/java/org/project/domain/label/dto/request/LabelCreateRequest.java
@@ -9,6 +9,6 @@ public record LabelCreateRequest(
         String name,
 
         @Schema(description = "부모 태그 ID", example = "1")
-        Long parentLabelId
+        Long parentTagId
 ) {
 }

--- a/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelHierarchyResponse.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Map;
 
 public record LabelHierarchyResponse(
-        LabelSummaryResponse parentLabel,
-        List<LabelTreeResponse> childLabels
+        LabelSummaryResponse parentTag,
+        List<LabelTreeResponse> childTags
 ) {
     public static LabelHierarchyResponse from(Label parentLabel, List<Label> childLabels, Map<Long, List<Label>> grandChildLabelsByParentId) {
         return new LabelHierarchyResponse(
@@ -22,21 +22,24 @@ public record LabelHierarchyResponse(
     }
 
     public record LabelTreeResponse(
-            Long labelId,
+            Long tagId,
             String name,
             String colorHex,
-            List<LabelTreeResponse> childLabels
+            Long parentId,
+            List<LabelTreeResponse> childTags
     ) {
         public static LabelTreeResponse from(Label label, List<Label> childLabels) {
             return new LabelTreeResponse(
                     label.getId(),
                     label.getName(),
                     label.getColorHex(),
+                    label.getParent() == null ? null : label.getParent().getId(),
                     childLabels.stream()
                             .map(child -> new LabelTreeResponse(
                                     child.getId(),
                                     child.getName(),
                                     child.getColorHex(),
+                                    child.getParent() == null ? null : child.getParent().getId(),
                                     List.of()
                             ))
                             .toList()

--- a/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelListResponse.java
@@ -1,32 +1,32 @@
 package org.project.domain.label.dto.response;
 
 import org.project.domain.label.entity.Label;
-import org.project.domain.memo.dto.response.MemoListDashboardResponse;
-
 import java.util.List;
 
 public record LabelListResponse(
-        List<MemoListDashboardResponse.LabelResponse> labels
+        List<LabelResponse> tags
 ) {
 
     public static LabelListResponse from(List<Label> labelEntities) {
         return new LabelListResponse(
                 labelEntities.stream()
-                        .map(MemoListDashboardResponse.LabelResponse::from)
+                        .map(LabelResponse::from)
                         .toList()
         );
     }
 
     public record LabelResponse(
-            Long labelId,
+            Long tagId,
             String name,
-            String colorHex
+            String colorHex,
+            Long parentId
     ) {
         public static LabelResponse from(Label label) {
             return new LabelResponse(
                     label.getId(),
                     label.getName(),
-                    label.getColorHex()
+                    label.getColorHex(),
+                    label.getParent() == null ? null : label.getParent().getId()
             );
         }
     }

--- a/src/main/java/org/project/domain/label/dto/response/LabelParentListResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelParentListResponse.java
@@ -5,7 +5,7 @@ import org.project.domain.label.entity.Label;
 import java.util.List;
 
 public record LabelParentListResponse(
-        List<LabelSummaryResponse> labels
+        List<LabelSummaryResponse> tags
 ) {
 
     public static LabelParentListResponse from(List<Label> labelEntities) {

--- a/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
+++ b/src/main/java/org/project/domain/label/dto/response/LabelSummaryResponse.java
@@ -3,15 +3,17 @@ package org.project.domain.label.dto.response;
 import org.project.domain.label.entity.Label;
 
 public record LabelSummaryResponse(
-        Long labelId,
+        Long tagId,
         String name,
-        String colorHex
+        String colorHex,
+        Long parentId
 ) {
     public static LabelSummaryResponse from(Label label) {
         return new LabelSummaryResponse(
                 label.getId(),
                 label.getName(),
-                label.getColorHex()
+                label.getColorHex(),
+                label.getParent() == null ? null : label.getParent().getId()
         );
     }
 }

--- a/src/main/java/org/project/domain/label/service/LabelService.java
+++ b/src/main/java/org/project/domain/label/service/LabelService.java
@@ -13,11 +13,11 @@ public interface LabelService {
 
     LabelParentListResponse getParentLabels(Long userId);
 
-    LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentLabelId);
+    LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentTagId);
 
     LabelSummaryResponse createLabel(Long userId, LabelCreateRequest request);
 
-    LabelSummaryResponse updateLabel(Long userId, Long labelId, LabelUpdateRequest request);
+    LabelSummaryResponse updateLabel(Long userId, Long tagId, LabelUpdateRequest request);
 
-    void deleteLabel(Long userId, Long labelId);
+    void deleteLabel(Long userId, Long tagId);
 }

--- a/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
+++ b/src/main/java/org/project/domain/label/service/LabelServiceImpl.java
@@ -46,12 +46,12 @@ public class LabelServiceImpl implements LabelService{
     }
 
     @Override
-    public LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentLabelId) {
-        Label parentLabel = labelRepository.findByIdAndUserIdAndParentIsNull(parentLabelId, userId)
+    public LabelHierarchyResponse getChildAndGrandChildLabels(Long userId, Long parentTagId) {
+        Label parentLabel = labelRepository.findByIdAndUserIdAndParentIsNull(parentTagId, userId)
                 .orElseThrow(() -> new LabelException(LabelErrorCode.PARENT_LABEL_NOT_FOUND));
 
-        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, parentLabelId);
-        List<Label> grandChildLabels = labelRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(userId, parentLabelId);
+        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, parentTagId);
+        List<Label> grandChildLabels = labelRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(userId, parentTagId);
 
         Map<Long, List<Label>> grandChildLabelsByParentId = grandChildLabels.stream()
                 .collect(Collectors.groupingBy(label -> label.getParent().getId()));
@@ -68,9 +68,9 @@ public class LabelServiceImpl implements LabelService{
     private LabelSummaryResponse createLabelInternal(Long userId, LabelCreateRequest request) {
         Label parentLabel = null;
 
-        if (request.parentLabelId() != null) {
-            validateParentLabelId(request.parentLabelId());
-            parentLabel = getLabelOrThrow(userId, request.parentLabelId());
+        if (request.parentTagId() != null) {
+            validateParentTagId(request.parentTagId());
+            parentLabel = getLabelOrThrow(userId, request.parentTagId());
             validateLabelDepth(parentLabel);
         }
 
@@ -88,9 +88,9 @@ public class LabelServiceImpl implements LabelService{
 
     @Override
     @Transactional
-    public LabelSummaryResponse updateLabel(Long userId, Long labelId, LabelUpdateRequest request) {
-        Label label = getLabelOrThrow(userId, labelId);
-        ensureLabelNameIsUnique(userId, request.name(), labelId);
+    public LabelSummaryResponse updateLabel(Long userId, Long tagId, LabelUpdateRequest request) {
+        Label label = getLabelOrThrow(userId, tagId);
+        ensureLabelNameIsUnique(userId, request.name(), tagId);
 
         label.rename(request.name());
         return LabelSummaryResponse.from(label);
@@ -98,10 +98,10 @@ public class LabelServiceImpl implements LabelService{
 
     @Override
     @Transactional
-    public void deleteLabel(Long userId, Long labelId) {
-        Label target = getLabelOrThrow(userId, labelId);
+    public void deleteLabel(Long userId, Long tagId) {
+        Label target = getLabelOrThrow(userId, tagId);
 
-        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, labelId);
+        List<Label> childLabels = labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, tagId);
         List<Label> grandChildLabels = new ArrayList<>();
         for (Label child : childLabels) {
             grandChildLabels.addAll(labelRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, child.getId()));
@@ -140,8 +140,8 @@ public class LabelServiceImpl implements LabelService{
         }
     }
 
-    private void validateParentLabelId(Long parentLabelId) {
-        if (parentLabelId <= 0) {
+    private void validateParentTagId(Long parentTagId) {
+        if (parentTagId <= 0) {
             throw new LabelException(LabelErrorCode.INVALID_PARENT_LABEL_ID);
         }
     }

--- a/src/test/java/org/project/domain/label/service/LabelServiceTest.java
+++ b/src/test/java/org/project/domain/label/service/LabelServiceTest.java
@@ -66,9 +66,10 @@ class LabelServiceTest {
         LabelParentListResponse response = labelService.getParentLabels(1L);
 
         // then
-        assertThat(response.labels()).hasSize(2);
-        assertThat(response.labels().get(0).name()).isEqualTo("parent-2");
-        assertThat(response.labels().get(0).colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.tags()).hasSize(2);
+        assertThat(response.tags().get(0).name()).isEqualTo("parent-2");
+        assertThat(response.tags().get(0).colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.tags().get(0).parentId()).isNull();
     }
 
     @Test
@@ -99,14 +100,17 @@ class LabelServiceTest {
         LabelHierarchyResponse response = labelService.getChildAndGrandChildLabels(1L, 10L);
 
         // then
-        assertThat(response.parentLabel().name()).isEqualTo("parent");
-        assertThat(response.parentLabel().colorHex()).isIn(LabelColorPalette.colors());
-        assertThat(response.childLabels()).hasSize(2);
-        assertThat(response.childLabels().get(0).name()).isEqualTo("child-2");
-        assertThat(response.childLabels().get(0).colorHex()).isIn(LabelColorPalette.colors());
-        assertThat(response.childLabels().get(0).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
+        assertThat(response.parentTag().name()).isEqualTo("parent");
+        assertThat(response.parentTag().colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.parentTag().parentId()).isNull();
+        assertThat(response.childTags()).hasSize(2);
+        assertThat(response.childTags().get(0).name()).isEqualTo("child-2");
+        assertThat(response.childTags().get(0).colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.childTags().get(0).parentId()).isEqualTo(10L);
+        assertThat(response.childTags().get(0).childTags()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
                 .containsExactly("grand-2");
-        assertThat(response.childLabels().get(1).childLabels()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
+        assertThat(response.childTags().get(0).childTags().get(0).parentId()).isEqualTo(12L);
+        assertThat(response.childTags().get(1).childTags()).extracting(LabelHierarchyResponse.LabelTreeResponse::name)
                 .containsExactly("grand-1");
     }
 
@@ -138,9 +142,10 @@ class LabelServiceTest {
         LabelSummaryResponse response = labelService.createLabel(1L, new LabelCreateRequest("parent", null));
 
         // then
-        assertThat(response.labelId()).isEqualTo(100L);
+        assertThat(response.tagId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
         assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.parentId()).isNull();
     }
 
     @Test
@@ -163,9 +168,10 @@ class LabelServiceTest {
         LabelSummaryResponse response = labelService.createLabel(1L, new LabelCreateRequest("child", 10L));
 
         // then
-        assertThat(response.labelId()).isEqualTo(101L);
+        assertThat(response.tagId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
         assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.parentId()).isEqualTo(10L);
     }
 
     @Test
@@ -183,9 +189,10 @@ class LabelServiceTest {
         LabelSummaryResponse response = labelService.updateLabel(1L, 10L, new LabelUpdateRequest("new"));
 
         // then
-        assertThat(response.labelId()).isEqualTo(10L);
+        assertThat(response.tagId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
         assertThat(response.colorHex()).isIn(LabelColorPalette.colors());
+        assertThat(response.parentId()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #150 

## 📝 Summary

- 태그 관련 API 경로를 `/api/v1/label`에서 `/api/v1/tag`로 변경했습니다.
- API path variable 네이밍을 `labelId` 기준에서 `tagId` 기준으로 변경했습니다.
- 태그 조회 응답 스펙을 `label` 기준에서 `tag` 기준으로 변경했습니다.
- 태그 응답에 `parentId` 필드를 추가했습니다.
  - 부모 태그: `parentId: null`
  - 자식 태그: `parentId: 부모 태그 ID`
- 클라로 보여지는 네이밍은 tag로 수정했지만, 애플리케이션에서 사용되는 클래스는 label로 유지했습니다. DB에 영향이 가기 때문에 DB 마이그레이션 작업이 있을때 한번에 진행하는 것이 좋을 것 같습니다.


## 🙏 Question & PR point

### 변경된 응답 예시

```json
{
  "code": 200,
  "msg": "응답 성공",
  "data": {
    "tags": [
      {
        "tagId": 74,
        "name": "졸업 프로젝트",
        "colorHex": "#A2E1DB",
        "parentId": null
      },
      {
        "tagId": 178,
        "name": "졸업프로젝트자식태그",
        "colorHex": "#F6EAC2",
        "parentId": 74
      }
    ]
  }
}

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
