### PR TITLE
[CHORE] 태그 생성 시 랜덤 컬러 지정 및 하위 태그 컬러 상속 처리

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -77,14 +77,16 @@ public record MemoListDashboardResponse(
     public record TagResponse(
             Long tagId,
             String name,
-            String colorHex
+            String backgroundColorHex,
+            String textColorHex
     ) {
 
         public static TagResponse from(Tag tag) {
             return new TagResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getColorHex()
+                    tag.getBackgroundColorHex(),
+                    tag.getTextColorHex()
             );
         }
     }

--- a/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
@@ -24,7 +24,8 @@ public record TagHierarchyResponse(
     public record TagTreeResponse(
             Long tagId,
             String name,
-            String colorHex,
+            String backgroundColorHex,
+            String textColorHex,
             Long parentId,
             List<TagTreeResponse> childTags
     ) {
@@ -32,13 +33,15 @@ public record TagHierarchyResponse(
             return new TagTreeResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getColorHex(),
+                    tag.getBackgroundColorHex(),
+                    tag.getTextColorHex(),
                     tag.getParent() == null ? null : tag.getParent().getId(),
                     childTags.stream()
                             .map(child -> new TagTreeResponse(
                                     child.getId(),
                                     child.getName(),
-                                    child.getColorHex(),
+                                    child.getBackgroundColorHex(),
+                                    child.getTextColorHex(),
                                     child.getParent() == null ? null : child.getParent().getId(),
                                     List.of()
                             ))

--- a/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
@@ -18,14 +18,16 @@ public record TagListResponse(
     public record TagResponse(
             Long tagId,
             String name,
-            String colorHex,
+            String backgroundColorHex,
+            String textColorHex,
             Long parentId
     ) {
         public static TagResponse from(Tag tag) {
             return new TagResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getColorHex(),
+                    tag.getBackgroundColorHex(),
+                    tag.getTextColorHex(),
                     tag.getParent() == null ? null : tag.getParent().getId()
             );
         }

--- a/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
@@ -5,14 +5,16 @@ import org.project.domain.tag.entity.Tag;
 public record TagSummaryResponse(
         Long tagId,
         String name,
-        String colorHex,
+        String backgroundColorHex,
+        String textColorHex,
         Long parentId
 ) {
     public static TagSummaryResponse from(Tag tag) {
         return new TagSummaryResponse(
                 tag.getId(),
                 tag.getName(),
-                tag.getColorHex(),
+                tag.getBackgroundColorHex(),
+                tag.getTextColorHex(),
                 tag.getParent() == null ? null : tag.getParent().getId()
         );
     }

--- a/src/main/java/org/project/domain/tag/entity/Tag.java
+++ b/src/main/java/org/project/domain/tag/entity/Tag.java
@@ -30,7 +30,10 @@ public class Tag extends BaseEntity {
     private String name;
 
     @Column(name = "color_hex", nullable = false, length = 7)
-    private String colorHex;
+    private String backgroundColorHex;
+
+    @Column(name = "text_color_hex", length = 7)
+    private String textColorHex;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -49,9 +52,12 @@ public class Tag extends BaseEntity {
     private List<MemoTag> memoTags = new ArrayList<>();
 
     public static Tag create(String name, User user) {
+        TagColorPalette.ColorSet colorSet = TagColorPalette.randomColorSet();
+
         return Tag.builder()
                 .name(name)
-                .colorHex(TagColorPalette.randomColor())
+                .backgroundColorHex(colorSet.backgroundColorHex())
+                .textColorHex(colorSet.textColorHex())
                 .user(user)
                 .build();
     }
@@ -59,7 +65,8 @@ public class Tag extends BaseEntity {
     public static Tag create(String name, User user, Tag parent) {
         return Tag.builder()
                 .name(name)
-                .colorHex(TagColorPalette.randomColor())
+                .backgroundColorHex(parent.getBackgroundColorHex())
+                .textColorHex(parent.getTextColorHex())
                 .user(user)
                 .parent(parent)
                 .build();
@@ -70,14 +77,28 @@ public class Tag extends BaseEntity {
     }
 
     public String getColorHex() {
-        return colorHex;
+        return getBackgroundColorHex();
+    }
+
+    public String getTextColorHex() {
+        if (textColorHex == null) {
+            return TagColorPalette.textColorOf(backgroundColorHex);
+        }
+        return textColorHex;
     }
 
     @PrePersist
     @PreUpdate
-    private void applyColorHex() {
-        if (colorHex == null) {
-            colorHex = TagColorPalette.randomColor();
+    private void applyColorHexes() {
+        if (backgroundColorHex == null) {
+            TagColorPalette.ColorSet colorSet = TagColorPalette.randomColorSet();
+            backgroundColorHex = colorSet.backgroundColorHex();
+            textColorHex = colorSet.textColorHex();
+            return;
+        }
+
+        if (textColorHex == null) {
+            textColorHex = TagColorPalette.textColorOf(backgroundColorHex);
         }
     }
 

--- a/src/main/java/org/project/domain/tag/util/TagColorPalette.java
+++ b/src/main/java/org/project/domain/tag/util/TagColorPalette.java
@@ -5,22 +5,57 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class TagColorPalette {
 
-    private static final List<String> COLORS = List.of(
-            "#ABDEE6", "#CBAACB", "#FFFFB5", "#FFCCB6", "#F3B0C3",
-            "#C6DBDA", "#FEE1E8", "#FED7C3", "#F6EAC2", "#ECD5E3",
-            "#FF968A", "#FFAEA5", "#FFC5BF", "#FFD8BE", "#FFC8A2",
-            "#D4F0F0", "#8FCACA", "#CCE2CB", "#B6CFB6", "#97C1A9",
-            "#FCB9AA", "#FFDBCC", "#ECEAE4", "#A2E1DB", "#55CBCD"
+    private static final List<ColorSet> COLOR_SETS = List.of(
+            new ColorSet("#D9ECFF", "#2194FF"),
+            new ColorSet("#E7DEFF", "#8259FF"),
+            new ColorSet("#D0F5F5", "#02A9A9"),
+            new ColorSet("#FFDBDC", "#E63639"),
+            new ColorSet("#FFD9C6", "#FF6200"),
+            new ColorSet("#FFEFC7", "#F99E00"),
+            new ColorSet("#D1DEFF", "#3A50E0"),
+            new ColorSet("#D2FFD5", "#02B50E"),
+            new ColorSet("#EFD3FF", "#D93FDB"),
+            new ColorSet("#FFE3EC", "#FF4E89")
     );
 
     private TagColorPalette() {
     }
 
-    public static String randomColor() {
-        return COLORS.get(ThreadLocalRandom.current().nextInt(COLORS.size()));
+    public static ColorSet randomColorSet() {
+        return COLOR_SETS.get(ThreadLocalRandom.current().nextInt(COLOR_SETS.size()));
     }
 
-    public static List<String> colors() {
-        return COLORS;
+    public static String randomColor() {
+        return randomColorSet().backgroundColorHex();
+    }
+
+    public static String textColorOf(String backgroundColorHex) {
+        return COLOR_SETS.stream()
+                .filter(colorSet -> colorSet.backgroundColorHex().equals(backgroundColorHex))
+                .map(ColorSet::textColorHex)
+                .findFirst()
+                .orElse(COLOR_SETS.get(0).textColorHex());
+    }
+
+    public static List<ColorSet> colorSets() {
+        return COLOR_SETS;
+    }
+
+    public static List<String> backgroundColors() {
+        return COLOR_SETS.stream()
+                .map(ColorSet::backgroundColorHex)
+                .toList();
+    }
+
+    public static List<String> textColors() {
+        return COLOR_SETS.stream()
+                .map(ColorSet::textColorHex)
+                .toList();
+    }
+
+    public record ColorSet(
+            String backgroundColorHex,
+            String textColorHex
+    ) {
     }
 }

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -804,8 +804,8 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#FF5722"),
-                                    new MemoListDashboardResponse.TagResponse(2L, "교양", "#4CAF50")
+                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF"),
+                                    new MemoListDashboardResponse.TagResponse(2L, "교양", "#D2FFD5", "#02B50E")
                             )
                     );
 
@@ -851,10 +851,12 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.memos[0].tagList.length()").value(2))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].colorHex").value("#FF5722"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].backgroundColorHex").value("#D9ECFF"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].textColorHex").value("#2194FF"))
                     .andExpect(jsonPath("$.data.memos[0].tagList[1].tagId").value(2L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[1].name").value("교양"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[1].colorHex").value("#4CAF50"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[1].backgroundColorHex").value("#D2FFD5"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[1].textColorHex").value("#02B50E"))
                     .andExpect(jsonPath("$.data.memos[1].memoId").value(2L))
                     .andExpect(jsonPath("$.data.memos[1].isPinned").value(true));
 
@@ -883,7 +885,7 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#FF5722")
+                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF")
                             )
                     );
 
@@ -907,7 +909,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.memos.length()").value(1))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].colorHex").value("#FF5722"));
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].backgroundColorHex").value("#D9ECFF"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].textColorHex").value("#2194FF"));
 
             verify(memoService, times(1))
                     .getMemosWithMedia(eq(userId), eq(tagIds), eq(null), eq(null), eq(20));
@@ -1052,9 +1055,9 @@ class MemoControllerTest {
                     List.of(image1, image2),
                     List.of(file),
                     List.of(
-                            new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#FF5722"),
-                            new MemoListDashboardResponse.TagResponse(2L, "교양", "#4CAF50"),
-                            new MemoListDashboardResponse.TagResponse(3L, "레퍼런스", "#2196F3")
+                            new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF"),
+                            new MemoListDashboardResponse.TagResponse(2L, "교양", "#D2FFD5", "#02B50E"),
+                            new MemoListDashboardResponse.TagResponse(3L, "레퍼런스", "#E7DEFF", "#8259FF")
                     ),
                     LocalDateTime.of(2026, 1, 16, 10, 30),
                     false,  // AI 생성 아님
@@ -1086,7 +1089,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.tagList.length()").value(3))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.tagList[0].colorHex").value("#FF5722"))
+                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#D9ECFF"))
+                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#2194FF"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
@@ -1109,7 +1113,7 @@ class MemoControllerTest {
                     "사용자가 직접 작성한 메모입니다.",
                     List.of(),
                     List.of(),
-                    List.of(new MemoListDashboardResponse.TagResponse(1L, "개인", "#9C27B0")),
+                    List.of(new MemoListDashboardResponse.TagResponse(1L, "개인", "#EFD3FF", "#D93FDB")),
                     LocalDateTime.of(2026, 1, 16, 12, 0),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
@@ -1126,7 +1130,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("개인"))
-                    .andExpect(jsonPath("$.data.tagList[0].colorHex").value("#9C27B0"))
+                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#EFD3FF"))
+                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#D93FDB"))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
 
@@ -1148,7 +1153,7 @@ class MemoControllerTest {
                     "이미지나 파일 없이 텍스트만 있습니다.",
                     List.of(),  // 이미지 없음
                     List.of(),  // 파일 없음
-                    List.of(new MemoListDashboardResponse.TagResponse(1L, "메모", "#795548")),
+                    List.of(new MemoListDashboardResponse.TagResponse(1L, "메모", "#FFE3EC", "#FF4E89")),
                     LocalDateTime.of(2026, 1, 16, 13, 0),
                     false,
                     List.of()
@@ -1169,7 +1174,8 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.files.length()").value(0))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("메모"))
-                    .andExpect(jsonPath("$.data.tagList[0].colorHex").value("#795548"));
+                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#FFE3EC"))
+                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#FF4E89"));
 
             verify(memoService, times(1))
                     .getOneMemoDetail(eq(userId), eq(memoId));

--- a/src/test/java/org/project/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/org/project/domain/tag/service/TagServiceTest.java
@@ -68,7 +68,8 @@ class TagServiceTest {
         // then
         assertThat(response.tags()).hasSize(2);
         assertThat(response.tags().get(0).name()).isEqualTo("parent-2");
-        assertThat(response.tags().get(0).colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.tags().get(0).backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
+        assertThat(response.tags().get(0).textColorHex()).isIn(TagColorPalette.textColors());
         assertThat(response.tags().get(0).parentId()).isNull();
     }
 
@@ -101,15 +102,21 @@ class TagServiceTest {
 
         // then
         assertThat(response.parentTag().name()).isEqualTo("parent");
-        assertThat(response.parentTag().colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.parentTag().backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
+        assertThat(response.parentTag().textColorHex()).isIn(TagColorPalette.textColors());
         assertThat(response.parentTag().parentId()).isNull();
         assertThat(response.childTags()).hasSize(2);
         assertThat(response.childTags().get(0).name()).isEqualTo("child-2");
-        assertThat(response.childTags().get(0).colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.childTags().get(0).backgroundColorHex()).isEqualTo(response.parentTag().backgroundColorHex());
+        assertThat(response.childTags().get(0).textColorHex()).isEqualTo(response.parentTag().textColorHex());
         assertThat(response.childTags().get(0).parentId()).isEqualTo(10L);
         assertThat(response.childTags().get(0).childTags()).extracting(TagHierarchyResponse.TagTreeResponse::name)
                 .containsExactly("grand-2");
         assertThat(response.childTags().get(0).childTags().get(0).parentId()).isEqualTo(12L);
+        assertThat(response.childTags().get(0).childTags().get(0).backgroundColorHex())
+                .isEqualTo(response.parentTag().backgroundColorHex());
+        assertThat(response.childTags().get(0).childTags().get(0).textColorHex())
+                .isEqualTo(response.parentTag().textColorHex());
         assertThat(response.childTags().get(1).childTags()).extracting(TagHierarchyResponse.TagTreeResponse::name)
                 .containsExactly("grand-1");
     }
@@ -144,7 +151,8 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
-        assertThat(response.colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
+        assertThat(response.textColorHex()).isIn(TagColorPalette.textColors());
         assertThat(response.parentId()).isNull();
     }
 
@@ -170,7 +178,8 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
-        assertThat(response.colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.backgroundColorHex()).isEqualTo(parent.getBackgroundColorHex());
+        assertThat(response.textColorHex()).isEqualTo(parent.getTextColorHex());
         assertThat(response.parentId()).isEqualTo(10L);
     }
 
@@ -191,7 +200,8 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
-        assertThat(response.colorHex()).isIn(TagColorPalette.colors());
+        assertThat(response.backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
+        assertThat(response.textColorHex()).isIn(TagColorPalette.textColors());
         assertThat(response.parentId()).isNull();
     }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #155 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 태그 컬러 팔레트를 지정된 10개 컬러 세트로 변경했습니다.
- 부모 태그 생성 시 10개 컬러 세트 중 하나를 랜덤으로 지정하도록 처리했습니다.
- 자식/손자 태그 생성 시 부모 태그의 배경색과 글자색을 그대로 상속하도록 처리했습니다.
- 태그 조회 및 메모 내 태그 응답에서 배경색과 글자색을 함께 내려주도록 변경했습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 태그 색상 정보를 배경색과 글자색으로 분리해 제공합니다.
  - 태그 목록, 계층 구조, 메모 목록 및 상세 화면에서 두 색상 정보를 확인할 수 있습니다.
  - 새 태그 생성 시 배경과 글자 색상 조합이 자동 적용됩니다.
  - 하위 태그는 상위 태그의 색상 설정을 상속합니다.
  - 배경색에 맞는 글자색이 자동으로 선택되어 가독성이 향상됩니다.

- **변경 사항**
  - 기존 단일 색상 정보 필드는 배경색·글자색 필드로 대체되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->