### PR TITLE
[CHORE] 태그 색상 응답을 색상 이름으로 변경

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -77,16 +77,14 @@ public record MemoListDashboardResponse(
     public record TagResponse(
             Long tagId,
             String name,
-            String backgroundColorHex,
-            String textColorHex
+            String color
     ) {
 
         public static TagResponse from(Tag tag) {
             return new TagResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getBackgroundColorHex(),
-                    tag.getTextColorHex()
+                    tag.getColor()
             );
         }
     }

--- a/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
@@ -24,8 +24,7 @@ public record TagHierarchyResponse(
     public record TagTreeResponse(
             Long tagId,
             String name,
-            String backgroundColorHex,
-            String textColorHex,
+            String color,
             Long parentId,
             List<TagTreeResponse> childTags
     ) {
@@ -33,15 +32,13 @@ public record TagHierarchyResponse(
             return new TagTreeResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getBackgroundColorHex(),
-                    tag.getTextColorHex(),
+                    tag.getColor(),
                     tag.getParent() == null ? null : tag.getParent().getId(),
                     childTags.stream()
                             .map(child -> new TagTreeResponse(
                                     child.getId(),
                                     child.getName(),
-                                    child.getBackgroundColorHex(),
-                                    child.getTextColorHex(),
+                                    child.getColor(),
                                     child.getParent() == null ? null : child.getParent().getId(),
                                     List.of()
                             ))

--- a/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
@@ -18,16 +18,14 @@ public record TagListResponse(
     public record TagResponse(
             Long tagId,
             String name,
-            String backgroundColorHex,
-            String textColorHex,
+            String color,
             Long parentId
     ) {
         public static TagResponse from(Tag tag) {
             return new TagResponse(
                     tag.getId(),
                     tag.getName(),
-                    tag.getBackgroundColorHex(),
-                    tag.getTextColorHex(),
+                    tag.getColor(),
                     tag.getParent() == null ? null : tag.getParent().getId()
             );
         }

--- a/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
@@ -5,16 +5,14 @@ import org.project.domain.tag.entity.Tag;
 public record TagSummaryResponse(
         Long tagId,
         String name,
-        String backgroundColorHex,
-        String textColorHex,
+        String color,
         Long parentId
 ) {
     public static TagSummaryResponse from(Tag tag) {
         return new TagSummaryResponse(
                 tag.getId(),
                 tag.getName(),
-                tag.getBackgroundColorHex(),
-                tag.getTextColorHex(),
+                tag.getColor(),
                 tag.getParent() == null ? null : tag.getParent().getId()
         );
     }

--- a/src/main/java/org/project/domain/tag/entity/Tag.java
+++ b/src/main/java/org/project/domain/tag/entity/Tag.java
@@ -29,11 +29,8 @@ public class Tag extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "color", length = 20)
+    @Column(name = "color", nullable = false, length = 20)
     private String color;
-
-    @Column(name = "color_hex", length = 7)
-    private String legacyColorHex;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -72,18 +69,11 @@ public class Tag extends BaseEntity {
         this.name = name;
     }
 
-    public String getColor() {
-        if (color == null) {
-            return TagColorPalette.colorOf(legacyColorHex);
-        }
-        return color;
-    }
-
     @PrePersist
     @PreUpdate
     private void applyColor() {
         if (color == null) {
-            color = TagColorPalette.colorOf(legacyColorHex);
+            color = TagColorPalette.randomColor();
         }
     }
 

--- a/src/main/java/org/project/domain/tag/entity/Tag.java
+++ b/src/main/java/org/project/domain/tag/entity/Tag.java
@@ -29,11 +29,11 @@ public class Tag extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "color_hex", nullable = false, length = 7)
-    private String backgroundColorHex;
+    @Column(name = "color", length = 20)
+    private String color;
 
-    @Column(name = "text_color_hex", length = 7)
-    private String textColorHex;
+    @Column(name = "color_hex", length = 7)
+    private String legacyColorHex;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -52,12 +52,9 @@ public class Tag extends BaseEntity {
     private List<MemoTag> memoTags = new ArrayList<>();
 
     public static Tag create(String name, User user) {
-        TagColorPalette.ColorSet colorSet = TagColorPalette.randomColorSet();
-
         return Tag.builder()
                 .name(name)
-                .backgroundColorHex(colorSet.backgroundColorHex())
-                .textColorHex(colorSet.textColorHex())
+                .color(TagColorPalette.randomColor())
                 .user(user)
                 .build();
     }
@@ -65,8 +62,7 @@ public class Tag extends BaseEntity {
     public static Tag create(String name, User user, Tag parent) {
         return Tag.builder()
                 .name(name)
-                .backgroundColorHex(parent.getBackgroundColorHex())
-                .textColorHex(parent.getTextColorHex())
+                .color(parent.getColor())
                 .user(user)
                 .parent(parent)
                 .build();
@@ -76,29 +72,18 @@ public class Tag extends BaseEntity {
         this.name = name;
     }
 
-    public String getColorHex() {
-        return getBackgroundColorHex();
-    }
-
-    public String getTextColorHex() {
-        if (textColorHex == null) {
-            return TagColorPalette.textColorOf(backgroundColorHex);
+    public String getColor() {
+        if (color == null) {
+            return TagColorPalette.colorOf(legacyColorHex);
         }
-        return textColorHex;
+        return color;
     }
 
     @PrePersist
     @PreUpdate
-    private void applyColorHexes() {
-        if (backgroundColorHex == null) {
-            TagColorPalette.ColorSet colorSet = TagColorPalette.randomColorSet();
-            backgroundColorHex = colorSet.backgroundColorHex();
-            textColorHex = colorSet.textColorHex();
-            return;
-        }
-
-        if (textColorHex == null) {
-            textColorHex = TagColorPalette.textColorOf(backgroundColorHex);
+    private void applyColor() {
+        if (color == null) {
+            color = TagColorPalette.colorOf(legacyColorHex);
         }
     }
 

--- a/src/main/java/org/project/domain/tag/util/TagColorPalette.java
+++ b/src/main/java/org/project/domain/tag/util/TagColorPalette.java
@@ -25,26 +25,6 @@ public final class TagColorPalette {
         return COLORS.get(ThreadLocalRandom.current().nextInt(COLORS.size()));
     }
 
-    public static String colorOf(String colorHex) {
-        if (colorHex == null) {
-            return COLORS.get(0);
-        }
-
-        return switch (colorHex) {
-            case "#D9ECFF" -> "light-blue";
-            case "#E7DEFF" -> "purple";
-            case "#D0F5F5" -> "cyan";
-            case "#FFDBDC" -> "red";
-            case "#FFD9C6" -> "orange";
-            case "#FFEFC7" -> "yellow";
-            case "#D1DEFF" -> "blue";
-            case "#D2FFD5" -> "green";
-            case "#EFD3FF" -> "magenta";
-            case "#FFE3EC" -> "pink";
-            default -> COLORS.get(0);
-        };
-    }
-
     public static List<String> colors() {
         return COLORS;
     }

--- a/src/main/java/org/project/domain/tag/util/TagColorPalette.java
+++ b/src/main/java/org/project/domain/tag/util/TagColorPalette.java
@@ -5,57 +5,47 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class TagColorPalette {
 
-    private static final List<ColorSet> COLOR_SETS = List.of(
-            new ColorSet("#D9ECFF", "#2194FF"),
-            new ColorSet("#E7DEFF", "#8259FF"),
-            new ColorSet("#D0F5F5", "#02A9A9"),
-            new ColorSet("#FFDBDC", "#E63639"),
-            new ColorSet("#FFD9C6", "#FF6200"),
-            new ColorSet("#FFEFC7", "#F99E00"),
-            new ColorSet("#D1DEFF", "#3A50E0"),
-            new ColorSet("#D2FFD5", "#02B50E"),
-            new ColorSet("#EFD3FF", "#D93FDB"),
-            new ColorSet("#FFE3EC", "#FF4E89")
+    private static final List<String> COLORS = List.of(
+            "light-blue",
+            "purple",
+            "cyan",
+            "red",
+            "orange",
+            "yellow",
+            "blue",
+            "green",
+            "magenta",
+            "pink"
     );
 
     private TagColorPalette() {
     }
 
-    public static ColorSet randomColorSet() {
-        return COLOR_SETS.get(ThreadLocalRandom.current().nextInt(COLOR_SETS.size()));
-    }
-
     public static String randomColor() {
-        return randomColorSet().backgroundColorHex();
+        return COLORS.get(ThreadLocalRandom.current().nextInt(COLORS.size()));
     }
 
-    public static String textColorOf(String backgroundColorHex) {
-        return COLOR_SETS.stream()
-                .filter(colorSet -> colorSet.backgroundColorHex().equals(backgroundColorHex))
-                .map(ColorSet::textColorHex)
-                .findFirst()
-                .orElse(COLOR_SETS.get(0).textColorHex());
+    public static String colorOf(String colorHex) {
+        if (colorHex == null) {
+            return COLORS.get(0);
+        }
+
+        return switch (colorHex) {
+            case "#D9ECFF" -> "light-blue";
+            case "#E7DEFF" -> "purple";
+            case "#D0F5F5" -> "cyan";
+            case "#FFDBDC" -> "red";
+            case "#FFD9C6" -> "orange";
+            case "#FFEFC7" -> "yellow";
+            case "#D1DEFF" -> "blue";
+            case "#D2FFD5" -> "green";
+            case "#EFD3FF" -> "magenta";
+            case "#FFE3EC" -> "pink";
+            default -> COLORS.get(0);
+        };
     }
 
-    public static List<ColorSet> colorSets() {
-        return COLOR_SETS;
-    }
-
-    public static List<String> backgroundColors() {
-        return COLOR_SETS.stream()
-                .map(ColorSet::backgroundColorHex)
-                .toList();
-    }
-
-    public static List<String> textColors() {
-        return COLOR_SETS.stream()
-                .map(ColorSet::textColorHex)
-                .toList();
-    }
-
-    public record ColorSet(
-            String backgroundColorHex,
-            String textColorHex
-    ) {
+    public static List<String> colors() {
+        return COLORS;
     }
 }

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -804,8 +804,8 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF"),
-                                    new MemoListDashboardResponse.TagResponse(2L, "교양", "#D2FFD5", "#02B50E")
+                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "light-blue"),
+                                    new MemoListDashboardResponse.TagResponse(2L, "교양", "green")
                             )
                     );
 
@@ -851,12 +851,10 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.memos[0].tagList.length()").value(2))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].backgroundColorHex").value("#D9ECFF"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].textColorHex").value("#2194FF"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].color").value("light-blue"))
                     .andExpect(jsonPath("$.data.memos[0].tagList[1].tagId").value(2L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[1].name").value("교양"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[1].backgroundColorHex").value("#D2FFD5"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[1].textColorHex").value("#02B50E"))
+                    .andExpect(jsonPath("$.data.memos[0].tagList[1].color").value("green"))
                     .andExpect(jsonPath("$.data.memos[1].memoId").value(2L))
                     .andExpect(jsonPath("$.data.memos[1].isPinned").value(true));
 
@@ -885,7 +883,7 @@ class MemoControllerTest {
                             true,
                             LocalDateTime.now(),
                             List.of(
-                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF")
+                                    new MemoListDashboardResponse.TagResponse(1L, "SOPT", "light-blue")
                             )
                     );
 
@@ -909,8 +907,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.memos.length()").value(1))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.memos[0].tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].backgroundColorHex").value("#D9ECFF"))
-                    .andExpect(jsonPath("$.data.memos[0].tagList[0].textColorHex").value("#2194FF"));
+                    .andExpect(jsonPath("$.data.memos[0].tagList[0].color").value("light-blue"));
 
             verify(memoService, times(1))
                     .getMemosWithMedia(eq(userId), eq(tagIds), eq(null), eq(null), eq(20));
@@ -1055,9 +1052,9 @@ class MemoControllerTest {
                     List.of(image1, image2),
                     List.of(file),
                     List.of(
-                            new MemoListDashboardResponse.TagResponse(1L, "SOPT", "#D9ECFF", "#2194FF"),
-                            new MemoListDashboardResponse.TagResponse(2L, "교양", "#D2FFD5", "#02B50E"),
-                            new MemoListDashboardResponse.TagResponse(3L, "레퍼런스", "#E7DEFF", "#8259FF")
+                            new MemoListDashboardResponse.TagResponse(1L, "SOPT", "light-blue"),
+                            new MemoListDashboardResponse.TagResponse(2L, "교양", "green"),
+                            new MemoListDashboardResponse.TagResponse(3L, "레퍼런스", "purple")
                     ),
                     LocalDateTime.of(2026, 1, 16, 10, 30),
                     false,  // AI 생성 아님
@@ -1089,8 +1086,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.tagList.length()").value(3))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("SOPT"))
-                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#D9ECFF"))
-                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#2194FF"))
+                    .andExpect(jsonPath("$.data.tagList[0].color").value("light-blue"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
@@ -1113,7 +1109,7 @@ class MemoControllerTest {
                     "사용자가 직접 작성한 메모입니다.",
                     List.of(),
                     List.of(),
-                    List.of(new MemoListDashboardResponse.TagResponse(1L, "개인", "#EFD3FF", "#D93FDB")),
+                    List.of(new MemoListDashboardResponse.TagResponse(1L, "개인", "magenta")),
                     LocalDateTime.of(2026, 1, 16, 12, 0),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
@@ -1130,8 +1126,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("개인"))
-                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#EFD3FF"))
-                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#D93FDB"))
+                    .andExpect(jsonPath("$.data.tagList[0].color").value("magenta"))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
 
@@ -1153,7 +1148,7 @@ class MemoControllerTest {
                     "이미지나 파일 없이 텍스트만 있습니다.",
                     List.of(),  // 이미지 없음
                     List.of(),  // 파일 없음
-                    List.of(new MemoListDashboardResponse.TagResponse(1L, "메모", "#FFE3EC", "#FF4E89")),
+                    List.of(new MemoListDashboardResponse.TagResponse(1L, "메모", "pink")),
                     LocalDateTime.of(2026, 1, 16, 13, 0),
                     false,
                     List.of()
@@ -1174,8 +1169,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.files.length()").value(0))
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("메모"))
-                    .andExpect(jsonPath("$.data.tagList[0].backgroundColorHex").value("#FFE3EC"))
-                    .andExpect(jsonPath("$.data.tagList[0].textColorHex").value("#FF4E89"));
+                    .andExpect(jsonPath("$.data.tagList[0].color").value("pink"));
 
             verify(memoService, times(1))
                     .getOneMemoDetail(eq(userId), eq(memoId));

--- a/src/test/java/org/project/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/org/project/domain/tag/service/TagServiceTest.java
@@ -68,8 +68,7 @@ class TagServiceTest {
         // then
         assertThat(response.tags()).hasSize(2);
         assertThat(response.tags().get(0).name()).isEqualTo("parent-2");
-        assertThat(response.tags().get(0).backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
-        assertThat(response.tags().get(0).textColorHex()).isIn(TagColorPalette.textColors());
+        assertThat(response.tags().get(0).color()).isIn(TagColorPalette.colors());
         assertThat(response.tags().get(0).parentId()).isNull();
     }
 
@@ -102,21 +101,17 @@ class TagServiceTest {
 
         // then
         assertThat(response.parentTag().name()).isEqualTo("parent");
-        assertThat(response.parentTag().backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
-        assertThat(response.parentTag().textColorHex()).isIn(TagColorPalette.textColors());
+        assertThat(response.parentTag().color()).isIn(TagColorPalette.colors());
         assertThat(response.parentTag().parentId()).isNull();
         assertThat(response.childTags()).hasSize(2);
         assertThat(response.childTags().get(0).name()).isEqualTo("child-2");
-        assertThat(response.childTags().get(0).backgroundColorHex()).isEqualTo(response.parentTag().backgroundColorHex());
-        assertThat(response.childTags().get(0).textColorHex()).isEqualTo(response.parentTag().textColorHex());
+        assertThat(response.childTags().get(0).color()).isEqualTo(response.parentTag().color());
         assertThat(response.childTags().get(0).parentId()).isEqualTo(10L);
         assertThat(response.childTags().get(0).childTags()).extracting(TagHierarchyResponse.TagTreeResponse::name)
                 .containsExactly("grand-2");
         assertThat(response.childTags().get(0).childTags().get(0).parentId()).isEqualTo(12L);
-        assertThat(response.childTags().get(0).childTags().get(0).backgroundColorHex())
-                .isEqualTo(response.parentTag().backgroundColorHex());
-        assertThat(response.childTags().get(0).childTags().get(0).textColorHex())
-                .isEqualTo(response.parentTag().textColorHex());
+        assertThat(response.childTags().get(0).childTags().get(0).color())
+                .isEqualTo(response.parentTag().color());
         assertThat(response.childTags().get(1).childTags()).extracting(TagHierarchyResponse.TagTreeResponse::name)
                 .containsExactly("grand-1");
     }
@@ -151,8 +146,7 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(100L);
         assertThat(response.name()).isEqualTo("parent");
-        assertThat(response.backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
-        assertThat(response.textColorHex()).isIn(TagColorPalette.textColors());
+        assertThat(response.color()).isIn(TagColorPalette.colors());
         assertThat(response.parentId()).isNull();
     }
 
@@ -178,8 +172,7 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(101L);
         assertThat(response.name()).isEqualTo("child");
-        assertThat(response.backgroundColorHex()).isEqualTo(parent.getBackgroundColorHex());
-        assertThat(response.textColorHex()).isEqualTo(parent.getTextColorHex());
+        assertThat(response.color()).isEqualTo(parent.getColor());
         assertThat(response.parentId()).isEqualTo(10L);
     }
 
@@ -200,8 +193,7 @@ class TagServiceTest {
         // then
         assertThat(response.tagId()).isEqualTo(10L);
         assertThat(response.name()).isEqualTo("new");
-        assertThat(response.backgroundColorHex()).isIn(TagColorPalette.backgroundColors());
-        assertThat(response.textColorHex()).isIn(TagColorPalette.textColors());
+        assertThat(response.color()).isIn(TagColorPalette.colors());
         assertThat(response.parentId()).isNull();
     }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #157 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 태그 색상 응답을 기존 색상 코드 기반 필드에서 색상 이름 기반 필드로 변경했습니다.
- 태그 생성 시 아래 10개 색상 이름 중 하나가 랜덤으로 지정되도록 변경했습니다.
  - 'light-blue', 'purple', 'cyan', 'red', 'orange', 'yellow', 'blue', 'green', 'magenta', 'pink'
- 자식/손자 태그 생성 시 부모 태그의 color 값을 그대로 상속하도록 처리했습니다.
- 태그 응답 및 메모 응답 내 tagList의 색상 정보를 color로 내려주도록 변경했습니다.

### 응답 변경 API
- GET /api/v1/tag
- POST /api/v1/tag
- PUT /api/v1/tag/{tagId}
- GET /api/v1/tag/parents
- GET /api/v1/tag/parents/{parentTagId}/children
- GET /api/v1/memo
- GET /api/v1/memo/ai
- GET /api/v1/memo/{memoId}
- GET /api/v1/memo/structure
- GET /api/v1/memo/search?query=...

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 태그 색상 표현이 배경색과 글자색 조합에서 하나의 색상 값으로 통합되었습니다.
  * 메모 목록, 태그 목록, 태그 계층 및 요약 화면의 태그 응답이 새로운 색상 형식을 사용합니다.
  * 태그 생성 시 무작위 색상 또는 상위 태그와 동일한 색상이 적용됩니다.
  * 기존 색상 데이터도 호환되도록 변환 지원이 유지됩니다.

* **테스트**
  * 메모 및 태그 관련 검증을 통합 색상 형식에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->