### PR TITLE
[Chore] 메모 GET / POST API 성능 개선 및 삭제 시 N+1 문제 해결

### DIFF
--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MemoFileRepository extends JpaRepository<MemoFile, Long> {
+public interface MemoFileRepository extends JpaRepository<MemoFile, Long>, MemoFileRepositoryCustom {
 
     List<MemoFile> findByMemoIdIn(List<Long> memoIds);
 

--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepositoryCustom.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.project.domain.memo.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MemoFileRepositoryCustom {
+
+    Map<Long, Long> countFilesByMemoId(List<Long> memoIds);
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.project.domain.memo.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.project.domain.memo.entity.QMemoFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class MemoFileRepositoryImpl implements MemoFileRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 메모별 파일 개수만 집계
+    @Override
+    public Map<Long, Long> countFilesByMemoId(List<Long> memoIds) {
+        QMemoFile memoFile = QMemoFile.memoFile;
+
+        List<Tuple> results = queryFactory
+                .select(memoFile.memo.id, memoFile.count())
+                .from(memoFile)
+                .where(memoFile.memo.id.in(memoIds))
+                .groupBy(memoFile.memo.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoFile.memo.id),
+                        t -> t.get(memoFile.count())
+                ));
+    }
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MemoImageRepository extends JpaRepository<MemoImage, Long> {
+public interface MemoImageRepository extends JpaRepository<MemoImage, Long>, MemoImageRepositoryCustom {
 
     List<MemoImage> findByMemoIdIn(List<Long> memoIds);
 

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryCustom.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.project.domain.memo.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MemoImageRepositoryCustom {
+
+    Map<Long, String> findRepresentativeImageS3Keys(List<Long> memoIds);
+
+    Map<Long, Long> countImagesByMemoId(List<Long> memoIds);
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryImpl.java
@@ -32,6 +32,9 @@ public class MemoImageRepositoryImpl implements MemoImageRepositoryCustom {
                                         .where(subImage.memo.id.eq(memoImage.memo.id))
                         )
                 )
+                // imagePriority가 동점이면 같은 memoId로 여러 행이 나올 수 있어서,
+                // id 오름차순으로 정렬해 항상 같은 이미지가 선택되도록 결정성을 보장함 (merge 함수는 첫 번째(a)를 유지)
+                .orderBy(memoImage.id.asc())
                 .fetch();
 
         return results.stream()

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepositoryImpl.java
@@ -1,0 +1,63 @@
+package org.project.domain.memo.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.project.domain.memo.entity.QMemoImage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class MemoImageRepositoryImpl implements MemoImageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 메모별 대표 이미지(우선순위 최소값)의 s3Key만 조회 — image_bytes/name/extension 등 안 쓰는 컬럼은 안 가져옴
+    @Override
+    public Map<Long, String> findRepresentativeImageS3Keys(List<Long> memoIds) {
+        QMemoImage memoImage = QMemoImage.memoImage;
+        QMemoImage subImage = new QMemoImage("subImage");
+
+        List<Tuple> results = queryFactory
+                .select(memoImage.memo.id, memoImage.imageS3Key)
+                .from(memoImage)
+                .where(
+                        memoImage.memo.id.in(memoIds),
+                        memoImage.imagePriority.eq(
+                                JPAExpressions.select(subImage.imagePriority.min())
+                                        .from(subImage)
+                                        .where(subImage.memo.id.eq(memoImage.memo.id))
+                        )
+                )
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoImage.memo.id),
+                        t -> t.get(memoImage.imageS3Key),
+                        (a, b) -> a
+                ));
+    }
+
+    // 메모별 이미지 개수만 집계 (행 자체를 안 끌고 옴)
+    @Override
+    public Map<Long, Long> countImagesByMemoId(List<Long> memoIds) {
+        QMemoImage memoImage = QMemoImage.memoImage;
+
+        List<Tuple> results = queryFactory
+                .select(memoImage.memo.id, memoImage.count())
+                .from(memoImage)
+                .where(memoImage.memo.id.in(memoIds))
+                .groupBy(memoImage.memo.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoImage.memo.id),
+                        t -> t.get(memoImage.count())
+                ));
+    }
+}

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -1,6 +1,11 @@
 package org.project.domain.memo.service;
 
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.project.domain.memo.entity.QMemoFile;
+import org.project.domain.memo.entity.QMemoImage;
 import org.project.domain.tag.entity.Tag;
 import org.project.domain.tag.repository.TagRepository;
 import org.project.domain.memo.config.MemoRecommendationProperties;
@@ -60,6 +65,8 @@ public class MemoServiceImpl implements MemoService {
     private final MemoImageRepository memoImageRepository;
     private final MemoFileRepository memoFileRepository;
     private final MemoTagRepository memoTagRepository;
+
+    private final JPAQueryFactory queryFactory;
 
     private final S3KeyUtil s3KeyUtil;
     private final S3Util s3Util;
@@ -225,25 +232,15 @@ public class MemoServiceImpl implements MemoService {
                 .map(Memo::getId)
                 .toList();
 
-        // 이미지 / 파일 조회
-        List<MemoImage> images = memoImageRepository.findByMemoIdIn(memoIds);
-        List<MemoFile> files = memoFileRepository.findByMemoIdIn(memoIds);
-
-        // memoId 기준 그룹핑
-        Map<Long, List<MemoImage>> imageMap = images.stream()
-                .collect(Collectors.groupingBy(
-                        image -> image.getMemo().getId()
-                ));
-
-        Map<Long, List<MemoFile>> fileMap = files.stream()
-                .collect(Collectors.groupingBy(
-                        file -> file.getMemo().getId()
-                ));
+        // 이미지 / 파일: 대표 이미지 s3Key + 개수만 조회 (전체 엔티티 조회 대신 프로젝션)
+        Map<Long, String> representativeImageS3KeyMap = findRepresentativeImageS3Keys(memoIds);
+        Map<Long, Long> imageCountMap = countImagesByMemoId(memoIds);
+        Map<Long, Long> fileCountMap = countFilesByMemoId(memoIds);
 
         // 응답 조립
         List<MemoListDashboardResponse.MemoDashboardResponse> responses =
                 memos.stream()
-                        .map(memo -> mapToDashboardResponse(memo, imageMap, fileMap))
+                        .map(memo -> mapToDashboardResponse(memo, representativeImageS3KeyMap, imageCountMap, fileCountMap))
                         .toList();
 
         return MemoListDashboardResponse.from(totalCount, responses);
@@ -285,25 +282,15 @@ public class MemoServiceImpl implements MemoService {
                 .map(Memo::getId)
                 .toList();
 
-        // 이미지 / 파일 조회
-        List<MemoImage> images = memoImageRepository.findByMemoIdIn(memoIds);
-        List<MemoFile> files = memoFileRepository.findByMemoIdIn(memoIds);
-
-        // memoId 기준 그룹핑
-        Map<Long, List<MemoImage>> imageMap = images.stream()
-                .collect(Collectors.groupingBy(
-                        image -> image.getMemo().getId()
-                ));
-
-        Map<Long, List<MemoFile>> fileMap = files.stream()
-                .collect(Collectors.groupingBy(
-                        file -> file.getMemo().getId()
-                ));
+        // 이미지 / 파일: 대표 이미지 s3Key + 개수만 조회 (전체 엔티티 조회 대신 프로젝션)
+        Map<Long, String> representativeImageS3KeyMap = findRepresentativeImageS3Keys(memoIds);
+        Map<Long, Long> imageCountMap = countImagesByMemoId(memoIds);
+        Map<Long, Long> fileCountMap = countFilesByMemoId(memoIds);
 
         // 응답 조립
         List<MemoListDashboardResponse.MemoDashboardResponse> responses =
                 memos.stream()
-                        .map(memo -> mapToDashboardResponse(memo, imageMap, fileMap))
+                        .map(memo -> mapToDashboardResponse(memo, representativeImageS3KeyMap, imageCountMap, fileCountMap))
                         .toList();
 
         return MemoListDashboardResponse.from(totalCount, responses);
@@ -479,7 +466,7 @@ public class MemoServiceImpl implements MemoService {
                 .orElseThrow(() -> new MemoException(MemoErrorCode.MEMO_NOT_FOUND));
     }
 
-    // 태그 처리 (중복 제거 + 우선순위)
+    // 태그 처리 (중복 제거 + 우선순위) — 이름 목록으로 기존 태그 일괄 조회 후, 없는 것만 일괄 생성
     private void attachTags(Memo memo, List<String> tagNames, User user) {
         if (tagNames == null || tagNames.isEmpty()) {
             return;
@@ -489,18 +476,30 @@ public class MemoServiceImpl implements MemoService {
                 .distinct()
                 .toList();
 
+        Map<String, Tag> tagsByName = findOrCreateTags(uniqueTagNames, user);
+
         for (int priority = 0; priority < uniqueTagNames.size(); priority++) {
             String tagName = uniqueTagNames.get(priority);
-            Tag tag = findOrCreateTag(tagName, user);
-            memo.addTag(tag, priority);
+            memo.addTag(tagsByName.get(tagName), priority);
         }
     }
 
-    private Tag findOrCreateTag(String tagName, User user) {
-        return tagRepository.findByNameAndUser(tagName, user)
-                .orElseGet(() -> tagRepository.save(
-                        Tag.create(tagName, user)
-                ));
+    private Map<String, Tag> findOrCreateTags(List<String> tagNames, User user) {
+        List<Tag> existingTags = tagRepository.findAllByNameInAndUser(tagNames, user);
+        Map<String, Tag> tagsByName = new HashMap<>(existingTags.stream()
+                .collect(Collectors.toMap(Tag::getName, Function.identity())));
+
+        List<Tag> newTags = tagNames.stream()
+                .filter(name -> !tagsByName.containsKey(name))
+                .map(name -> Tag.create(name, user))
+                .toList();
+
+        if (!newTags.isEmpty()) {
+            tagRepository.saveAll(newTags)
+                    .forEach(tag -> tagsByName.put(tag.getName(), tag));
+        }
+
+        return tagsByName;
     }
 
     private void validateSourceMemos(List<Long> sourceMemoIds, List<Memo> sourceMemos) {
@@ -614,28 +613,82 @@ public class MemoServiceImpl implements MemoService {
 
     private MemoListDashboardResponse.MemoDashboardResponse mapToDashboardResponse(
             Memo memo,
-            Map<Long, List<MemoImage>> imageMap,
-            Map<Long, List<MemoFile>> fileMap
+            Map<Long, String> representativeImageS3KeyMap,
+            Map<Long, Long> imageCountMap,
+            Map<Long, Long> fileCountMap
     ) {
-        List<MemoImage> memoImages = imageMap.getOrDefault(memo.getId(), List.of());
-        List<MemoFile> memoFiles = fileMap.getOrDefault(memo.getId(), List.of());
-
-        String representativeImageUrl = findRepresentativeImage(memoImages);
+        String s3Key = representativeImageS3KeyMap.get(memo.getId());
+        String representativeImageUrl = (s3Key != null) ? s3Util.generatePresignedUrl(s3Key) : null;
 
         return MemoListDashboardResponse.MemoDashboardResponse.of(
                 memo,
                 MarkdownUtil.strip(memo.getContent()),
                 representativeImageUrl,
-                memoImages.size(),
-                memoFiles.size()
+                imageCountMap.getOrDefault(memo.getId(), 0L).intValue(),
+                fileCountMap.getOrDefault(memo.getId(), 0L).intValue()
         );
     }
 
-    private String findRepresentativeImage(List<MemoImage> images) {
-        return images.stream()
-                .min(Comparator.comparingInt(MemoImage::getImagePriority))
-                .map(img -> s3Util.generatePresignedUrl(img.getImageS3Key()))
-                .orElse(null);
+    // 메모별 대표 이미지(우선순위 최소값)의 s3Key만 조회 — image_bytes/name/extension 등 안 쓰는 컬럼은 안 가져옴
+    private Map<Long, String> findRepresentativeImageS3Keys(List<Long> memoIds) {
+        QMemoImage memoImage = QMemoImage.memoImage;
+        QMemoImage subImage = new QMemoImage("subImage");
+
+        List<Tuple> results = queryFactory
+                .select(memoImage.memo.id, memoImage.imageS3Key)
+                .from(memoImage)
+                .where(
+                        memoImage.memo.id.in(memoIds),
+                        memoImage.imagePriority.eq(
+                                JPAExpressions.select(subImage.imagePriority.min())
+                                        .from(subImage)
+                                        .where(subImage.memo.id.eq(memoImage.memo.id))
+                        )
+                )
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoImage.memo.id),
+                        t -> t.get(memoImage.imageS3Key),
+                        (a, b) -> a
+                ));
+    }
+
+    // 메모별 이미지 개수만 집계 (행 자체를 안 끌고 옴)
+    private Map<Long, Long> countImagesByMemoId(List<Long> memoIds) {
+        QMemoImage memoImage = QMemoImage.memoImage;
+
+        List<Tuple> results = queryFactory
+                .select(memoImage.memo.id, memoImage.count())
+                .from(memoImage)
+                .where(memoImage.memo.id.in(memoIds))
+                .groupBy(memoImage.memo.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoImage.memo.id),
+                        t -> t.get(memoImage.count())
+                ));
+    }
+
+    // 메모별 파일 개수만 집계
+    private Map<Long, Long> countFilesByMemoId(List<Long> memoIds) {
+        QMemoFile memoFile = QMemoFile.memoFile;
+
+        List<Tuple> results = queryFactory
+                .select(memoFile.memo.id, memoFile.count())
+                .from(memoFile)
+                .where(memoFile.memo.id.in(memoIds))
+                .groupBy(memoFile.memo.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(memoFile.memo.id),
+                        t -> t.get(memoFile.count())
+                ));
     }
 
     private List<MemoDetailResponse.ImageInfo> mapToImageInfos(List<MemoImage> memoImages) {

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -1,11 +1,6 @@
 package org.project.domain.memo.service;
 
-import com.querydsl.core.Tuple;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.project.domain.memo.entity.QMemoFile;
-import org.project.domain.memo.entity.QMemoImage;
 import org.project.domain.tag.entity.Tag;
 import org.project.domain.tag.repository.TagRepository;
 import org.project.domain.memo.config.MemoRecommendationProperties;
@@ -65,8 +60,6 @@ public class MemoServiceImpl implements MemoService {
     private final MemoImageRepository memoImageRepository;
     private final MemoFileRepository memoFileRepository;
     private final MemoTagRepository memoTagRepository;
-
-    private final JPAQueryFactory queryFactory;
 
     private final S3KeyUtil s3KeyUtil;
     private final S3Util s3Util;
@@ -233,9 +226,9 @@ public class MemoServiceImpl implements MemoService {
                 .toList();
 
         // 이미지 / 파일: 대표 이미지 s3Key + 개수만 조회 (전체 엔티티 조회 대신 프로젝션)
-        Map<Long, String> representativeImageS3KeyMap = findRepresentativeImageS3Keys(memoIds);
-        Map<Long, Long> imageCountMap = countImagesByMemoId(memoIds);
-        Map<Long, Long> fileCountMap = countFilesByMemoId(memoIds);
+        Map<Long, String> representativeImageS3KeyMap = memoImageRepository.findRepresentativeImageS3Keys(memoIds);
+        Map<Long, Long> imageCountMap = memoImageRepository.countImagesByMemoId(memoIds);
+        Map<Long, Long> fileCountMap = memoFileRepository.countFilesByMemoId(memoIds);
 
         // 응답 조립
         List<MemoListDashboardResponse.MemoDashboardResponse> responses =
@@ -283,9 +276,9 @@ public class MemoServiceImpl implements MemoService {
                 .toList();
 
         // 이미지 / 파일: 대표 이미지 s3Key + 개수만 조회 (전체 엔티티 조회 대신 프로젝션)
-        Map<Long, String> representativeImageS3KeyMap = findRepresentativeImageS3Keys(memoIds);
-        Map<Long, Long> imageCountMap = countImagesByMemoId(memoIds);
-        Map<Long, Long> fileCountMap = countFilesByMemoId(memoIds);
+        Map<Long, String> representativeImageS3KeyMap = memoImageRepository.findRepresentativeImageS3Keys(memoIds);
+        Map<Long, Long> imageCountMap = memoImageRepository.countImagesByMemoId(memoIds);
+        Map<Long, Long> fileCountMap = memoFileRepository.countFilesByMemoId(memoIds);
 
         // 응답 조립
         List<MemoListDashboardResponse.MemoDashboardResponse> responses =
@@ -627,68 +620,6 @@ public class MemoServiceImpl implements MemoService {
                 imageCountMap.getOrDefault(memo.getId(), 0L).intValue(),
                 fileCountMap.getOrDefault(memo.getId(), 0L).intValue()
         );
-    }
-
-    // 메모별 대표 이미지(우선순위 최소값)의 s3Key만 조회 — image_bytes/name/extension 등 안 쓰는 컬럼은 안 가져옴
-    private Map<Long, String> findRepresentativeImageS3Keys(List<Long> memoIds) {
-        QMemoImage memoImage = QMemoImage.memoImage;
-        QMemoImage subImage = new QMemoImage("subImage");
-
-        List<Tuple> results = queryFactory
-                .select(memoImage.memo.id, memoImage.imageS3Key)
-                .from(memoImage)
-                .where(
-                        memoImage.memo.id.in(memoIds),
-                        memoImage.imagePriority.eq(
-                                JPAExpressions.select(subImage.imagePriority.min())
-                                        .from(subImage)
-                                        .where(subImage.memo.id.eq(memoImage.memo.id))
-                        )
-                )
-                .fetch();
-
-        return results.stream()
-                .collect(Collectors.toMap(
-                        t -> t.get(memoImage.memo.id),
-                        t -> t.get(memoImage.imageS3Key),
-                        (a, b) -> a
-                ));
-    }
-
-    // 메모별 이미지 개수만 집계 (행 자체를 안 끌고 옴)
-    private Map<Long, Long> countImagesByMemoId(List<Long> memoIds) {
-        QMemoImage memoImage = QMemoImage.memoImage;
-
-        List<Tuple> results = queryFactory
-                .select(memoImage.memo.id, memoImage.count())
-                .from(memoImage)
-                .where(memoImage.memo.id.in(memoIds))
-                .groupBy(memoImage.memo.id)
-                .fetch();
-
-        return results.stream()
-                .collect(Collectors.toMap(
-                        t -> t.get(memoImage.memo.id),
-                        t -> t.get(memoImage.count())
-                ));
-    }
-
-    // 메모별 파일 개수만 집계
-    private Map<Long, Long> countFilesByMemoId(List<Long> memoIds) {
-        QMemoFile memoFile = QMemoFile.memoFile;
-
-        List<Tuple> results = queryFactory
-                .select(memoFile.memo.id, memoFile.count())
-                .from(memoFile)
-                .where(memoFile.memo.id.in(memoIds))
-                .groupBy(memoFile.memo.id)
-                .fetch();
-
-        return results.stream()
-                .collect(Collectors.toMap(
-                        t -> t.get(memoFile.memo.id),
-                        t -> t.get(memoFile.count())
-                ));
     }
 
     private List<MemoDetailResponse.ImageInfo> mapToImageInfos(List<MemoImage> memoImages) {

--- a/src/main/java/org/project/domain/tag/repository/TagRepository.java
+++ b/src/main/java/org/project/domain/tag/repository/TagRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface TagRepository extends JpaRepository<Tag, Long> {
     Optional<Tag> findByNameAndUser(String name, User user);
 
+    List<Tag> findAllByNameInAndUser(List<String> names, User user);
+
     Optional<Tag> findByNameAndUserId(String name, Long userId);
 
     List<Tag> findAllByUserId(Long userId);

--- a/src/main/java/org/project/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/org/project/domain/tag/service/TagServiceImpl.java
@@ -102,10 +102,7 @@ public class TagServiceImpl implements TagService{
         Tag target = getTagOrThrow(userId, tagId);
 
         List<Tag> childTags = tagRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, tagId);
-        List<Tag> grandChildTags = new ArrayList<>();
-        for (Tag child : childTags) {
-            grandChildTags.addAll(tagRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(userId, child.getId()));
-        }
+        List<Tag> grandChildTags = tagRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(userId, tagId);
 
         List<Long> tagIds = new ArrayList<>();
         grandChildTags.forEach(tag -> tagIds.add(tag.getId()));
@@ -116,9 +113,10 @@ public class TagServiceImpl implements TagService{
             memoTagRepository.deleteByTagIds(tagIds);
         }
 
-        grandChildTags.forEach(tagRepository::delete);
-        childTags.forEach(tagRepository::delete);
-        tagRepository.delete(target);
+        List<Tag> allTags = new ArrayList<>(grandChildTags);
+        allTags.addAll(childTags);
+        allTags.add(target);
+        tagRepository.deleteAllInBatch(allTags);
     }
 
     private Tag getTagOrThrow(Long userId, Long tagId) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -125,6 +125,11 @@ management:
     redis:
       enabled: false # Redis가 없어도 전체 앱은 UP 상태로 유지
 
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true # 이게 없으면 tomcat_threads_* 지표가 안 잡힘
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+        generate_statistics: true
     show-sql: true
 
   web:
@@ -120,3 +121,27 @@ swagger:
   auth:
     username: ${SWAGGER_USERNAME}
     password: ${SWAGGER_PASSWORD}
+
+
+management:
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  health:
+    redis:
+      enabled: false
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+logging:
+  level:
+    org.hibernate.stat: DEBUG
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: DEBUG

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -131,6 +131,11 @@ cloud:
     s3:
       bucket: clustar-bucket-01
 
+swagger:
+  auth:
+    username: ${SWAGGER_USERNAME}
+    password: ${SWAGGER_PASSWORD}
+
 logging:
   level:
     org.springframework.ai: INFO

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -42,6 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 
@@ -223,7 +224,7 @@ class MemoServiceImplTest {
             when(userRepository.findById(user.getId()))
                     .thenReturn(Optional.of(user));
 
-            when(tagRepository.findByNameAndUser(anyString(), any()))
+            when(tagRepository.findAllByNameInAndUser(anyList(), any()))
                     .thenThrow(new RuntimeException("태그 오류"));
 
             // when & then
@@ -377,11 +378,13 @@ class MemoServiceImplTest {
                     any(PageRequest.class)
             )).thenReturn(List.of(memo1, memo2));
 
-            when(memoImageRepository.findByMemoIdIn(List.of(1L, 2L)))
-                    .thenReturn(List.of(image1));
+            when(memoImageRepository.findRepresentativeImageS3Keys(List.of(1L, 2L)))
+                    .thenReturn(Map.of(1L, image1.getImageS3Key()));
+            when(memoImageRepository.countImagesByMemoId(List.of(1L, 2L)))
+                    .thenReturn(Map.of(1L, 1L));
 
-            when(memoFileRepository.findByMemoIdIn(List.of(1L, 2L)))
-                    .thenReturn(List.of(file1));
+            when(memoFileRepository.countFilesByMemoId(List.of(1L, 2L)))
+                    .thenReturn(Map.of(1L, 1L));
 
             // when
             MemoListDashboardResponse response =
@@ -414,8 +417,9 @@ class MemoServiceImplTest {
                     any(PageRequest.class)
             );
 
-            verify(memoImageRepository).findByMemoIdIn(List.of(1L, 2L));
-            verify(memoFileRepository).findByMemoIdIn(List.of(1L, 2L));
+            verify(memoImageRepository).findRepresentativeImageS3Keys(List.of(1L, 2L));
+            verify(memoImageRepository).countImagesByMemoId(List.of(1L, 2L));
+            verify(memoFileRepository).countFilesByMemoId(List.of(1L, 2L));
         }
 
         @Test
@@ -468,11 +472,13 @@ class MemoServiceImplTest {
                     any(PageRequest.class)
             )).thenReturn(List.of(memo1));
 
-            when(memoImageRepository.findByMemoIdIn(List.of(1L)))
-                    .thenReturn(List.of(image1));
+            when(memoImageRepository.findRepresentativeImageS3Keys(List.of(1L)))
+                    .thenReturn(Map.of(1L, image1.getImageS3Key()));
+            when(memoImageRepository.countImagesByMemoId(List.of(1L)))
+                    .thenReturn(Map.of(1L, 1L));
 
-            when(memoFileRepository.findByMemoIdIn(List.of(1L)))
-                    .thenReturn(List.of()); // 파일 없음
+            when(memoFileRepository.countFilesByMemoId(List.of(1L)))
+                    .thenReturn(Map.of()); // 파일 없음
 
             // when
             MemoListDashboardResponse response =
@@ -502,8 +508,9 @@ class MemoServiceImplTest {
                     isNull(),
                     any(PageRequest.class)
             );
-            verify(memoImageRepository).findByMemoIdIn(List.of(1L));
-            verify(memoFileRepository).findByMemoIdIn(List.of(1L));
+            verify(memoImageRepository).findRepresentativeImageS3Keys(List.of(1L));
+            verify(memoImageRepository).countImagesByMemoId(List.of(1L));
+            verify(memoFileRepository).countFilesByMemoId(List.of(1L));
         }
 
         @Test
@@ -535,11 +542,13 @@ class MemoServiceImplTest {
                     any(PageRequest.class)
             )).thenReturn(List.of(nextMemo));
 
-            when(memoImageRepository.findByMemoIdIn(List.of(1L)))
-                    .thenReturn(List.of());
+            when(memoImageRepository.findRepresentativeImageS3Keys(List.of(1L)))
+                    .thenReturn(Map.of());
+            when(memoImageRepository.countImagesByMemoId(List.of(1L)))
+                    .thenReturn(Map.of());
 
-            when(memoFileRepository.findByMemoIdIn(List.of(1L)))
-                    .thenReturn(List.of());
+            when(memoFileRepository.countFilesByMemoId(List.of(1L)))
+                    .thenReturn(Map.of());
 
             // when
             MemoListDashboardResponse response =

--- a/src/test/java/org/project/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/org/project/domain/tag/service/TagServiceTest.java
@@ -223,6 +223,35 @@ class TagServiceTest {
     }
 
     @Test
+    @DisplayName("손자 태그가 있으면 손자까지 함께 삭제한다")
+    void deleteTag_withGrandChild_success() {
+        // given
+        User user = createUser();
+        Tag parent = Tag.create("parent", user);
+        ReflectionTestUtils.setField(parent, "id", 10L);
+
+        Tag child = Tag.create("child", user, parent);
+        ReflectionTestUtils.setField(child, "id", 11L);
+
+        Tag grandChild = Tag.create("grandChild", user, child);
+        ReflectionTestUtils.setField(grandChild, "id", 12L);
+
+        when(tagRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(parent));
+        when(tagRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 10L))
+                .thenReturn(List.of(child));
+        when(tagRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(1L, 10L))
+                .thenReturn(List.of(grandChild));
+
+        // when
+        tagService.deleteTag(1L, 10L);
+
+        // then
+        verify(tagRepository).findByUserIdAndParentParentIdOrderByCreatedAtDesc(1L, 10L);
+        verify(memoTagRepository).deleteByTagIds(List.of(12L, 11L, 10L));
+        verify(tagRepository).deleteAllInBatch(List.of(grandChild, child, parent));
+    }
+
+    @Test
     @DisplayName("중복된 태그 이름이면 예외를 던진다")
     void createTag_duplicateName_fail() {
         // given

--- a/src/test/java/org/project/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/org/project/domain/tag/service/TagServiceTest.java
@@ -211,7 +211,7 @@ class TagServiceTest {
         when(tagRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(parent));
         when(tagRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 10L))
                 .thenReturn(List.of(child));
-        when(tagRepository.findByUserIdAndParentIdOrderByCreatedAtDesc(1L, 11L))
+        when(tagRepository.findByUserIdAndParentParentIdOrderByCreatedAtDesc(1L, 10L))
                 .thenReturn(List.of());
 
         // when
@@ -219,8 +219,7 @@ class TagServiceTest {
 
         // then
         verify(memoTagRepository).deleteByTagIds(List.of(11L, 10L));
-        verify(tagRepository).delete(child);
-        verify(tagRepository).delete(parent);
+        verify(tagRepository).deleteAllInBatch(List.of(child, parent));
     }
 
     @Test


### PR DESCRIPTION
## 📣 Related Issue

- close #160
- close #161

## 📝 Summary

- 메모 목록조회 API 이미지/파일 과다조회 개선
- 메모 생성 시 태그조회 부분도 N+1이라 배치 조회로 함께 개선
- 태그 삭제 API N+1 해결
- perf 프로필 swagger 인증 설정 누락 수
- 로컬/dev 톰캣, Hikari 모니터링 지표 노출 설정 추가

## 🙏 Question & PR point

- 로컬 부하테스트 기준 메모 목록조회 p95 약 52% 개선, 태그 삭제 쿼리 30개 → 5개로 감소 확인했습니다
- 메모 목록조회 API (20명 동시요청 기준)
     - p95 54ms → 26ms (-52%) 
     - 처리량 528 → 997건/초 (+89%)
- 태그 삭제 API 쿼리 개수: 30개 → 5개 

## 📬 Postman

<!-- 스크린샷 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 메모 목록과 대시보드에서 대표 이미지, 이미지 수, 첨부 파일 수를 더 효율적으로 표시합니다.
  - 여러 메모의 미디어 정보를 일괄 처리해 목록 조회 성능을 개선했습니다.
  - 태그 생성·삭제를 일괄 처리하여 태그 관리 속도와 안정성을 높였습니다.
  - 하위 태그가 포함된 태그 삭제가 한 번에 처리되도록 개선했습니다.

- **운영 개선**
  - 개발 및 성능 점검 환경에서 상태 모니터링과 성능 지표 확인을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->