### PR TITLE
[CHORE] 응답 DTO의 required·nullable OpenAPI 스키마 명세화

### DIFF
--- a/src/main/java/org/project/domain/ai/dto/response/AiEvaluationResult.java
+++ b/src/main/java/org/project/domain/ai/dto/response/AiEvaluationResult.java
@@ -1,5 +1,8 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = {"relevancePass", "promptFaithfulnessScore", "groundednessScore", "taskAlignmentPass"})
 public record AiEvaluationResult(
         double relevancePass,
         double promptFaithfulnessScore,

--- a/src/main/java/org/project/domain/ai/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/ChatRoomListResponse.java
@@ -1,10 +1,12 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.ai.entity.ChatRoom;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(requiredProperties = "chatRooms")
 public record ChatRoomListResponse(
         List<ChatRoomResponse> chatRooms
 ) {
@@ -13,6 +15,7 @@ public record ChatRoomListResponse(
         return new ChatRoomListResponse(chatRooms);
     }
 
+    @Schema(requiredProperties = {"chatRoomId", "createdAt"})
     public record ChatRoomResponse(
             Long chatRoomId,
             LocalDateTime createdAt
@@ -26,4 +29,3 @@ public record ChatRoomListResponse(
         }
     }
 }
-

--- a/src/main/java/org/project/domain/ai/dto/response/CreateChatRoomResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/CreateChatRoomResponse.java
@@ -1,5 +1,8 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = "chatRoomId")
 public record CreateChatRoomResponse(
         Long chatRoomId
 ) {
@@ -7,4 +10,3 @@ public record CreateChatRoomResponse(
         return new CreateChatRoomResponse(chatRoomId);
     }
 }
-

--- a/src/main/java/org/project/domain/ai/dto/response/EmbeddingFailureResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/EmbeddingFailureResponse.java
@@ -1,14 +1,17 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.ai.entity.EmbeddingFailure;
 
 import java.time.LocalDateTime;
 
+@Schema(requiredProperties = {"id", "memoId", "embeddingType", "failedAt", "errorMessage"})
 public record EmbeddingFailureResponse(
         Long id,
         Long memoId,
         String embeddingType,
         LocalDateTime failedAt,
+        @Schema(nullable = true)
         String errorMessage
 ) {
     public static EmbeddingFailureResponse from(EmbeddingFailure failure) {

--- a/src/main/java/org/project/domain/ai/dto/response/MemoAiResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/MemoAiResponse.java
@@ -1,10 +1,12 @@
 package org.project.domain.ai.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.ai.dto.MemoAiOptions;
 
 import java.util.List;
 
+@Schema(requiredProperties = {"title", "content", "option", "memoIds", "usedPrompt"})
 public record MemoAiResponse(
         String title,
         String content,

--- a/src/main/java/org/project/domain/ai/dto/response/MemoAiResponseForPlan.java
+++ b/src/main/java/org/project/domain/ai/dto/response/MemoAiResponseForPlan.java
@@ -1,5 +1,8 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = {"aiResponse", "evaluation"})
 public record MemoAiResponseForPlan(
         MemoAiResponse aiResponse,
         AiEvaluationResult evaluation

--- a/src/main/java/org/project/domain/ai/dto/response/ReEmbeddingResultResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/ReEmbeddingResultResponse.java
@@ -1,9 +1,14 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = {"memoId", "textSucceeded", "imageSucceeded", "fileSucceeded"})
 public record ReEmbeddingResultResponse(
         Long memoId,
         Boolean textSucceeded,   // 항상 시도됨
-        Boolean imageSucceeded,  // null = 이미지 없음(시도 안 함)
-        Boolean fileSucceeded    // null = 파일 없음(시도 안 함)
+        @Schema(nullable = true, description = "이미지 재임베딩 성공 여부. 이미지 첨부가 없어 시도하지 않은 경우 null")
+        Boolean imageSucceeded,
+        @Schema(nullable = true, description = "파일 재임베딩 성공 여부. 파일 첨부가 없어 시도하지 않은 경우 null")
+        Boolean fileSucceeded
 ) {
 }

--- a/src/main/java/org/project/domain/ai/dto/response/ReEmbeddingStartedResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/ReEmbeddingStartedResponse.java
@@ -1,5 +1,8 @@
 package org.project.domain.ai.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(requiredProperties = "message")
 public record ReEmbeddingStartedResponse(
         String message
 ) {

--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
+@Schema(requiredProperties = {"memoId", "title", "content", "images", "files", "tagList", "createdAt", "isAiGenerated", "sourceMemoTitleList"})
 public record MemoDetailResponse(
 
         @Schema(description = "메모 ID", example = "1")
@@ -41,7 +42,7 @@ public record MemoDetailResponse(
         List<String> sourceMemoTitleList
 ) {
 
-    @Schema(description = "이미지 정보")
+    @Schema(description = "이미지 정보", requiredProperties = {"imageId", "imageUrl", "imageName", "imageExtension", "imageSize"})
     public record ImageInfo(
 
             @Schema(description = "이미지 ID", example = "1")
@@ -50,17 +51,17 @@ public record MemoDetailResponse(
             @Schema(description = "이미지 URL (Presigned URL)")
             String imageUrl,
 
-            @Schema(description = "이미지 파일명", example = "seminar_slide.png")
+            @Schema(description = "이미지 파일명", example = "seminar_slide.png", nullable = true)
             String imageName,
 
-            @Schema(description = "이미지 확장자", example = "png")
+            @Schema(description = "이미지 확장자", example = "png", nullable = true)
             String imageExtension,
 
-            @Schema(description = "이미지 크기", example = "0.24MB")
+            @Schema(description = "이미지 크기", example = "0.24MB", nullable = true)
             String imageSize
     ) {}
 
-    @Schema(description = "첨부 파일 정보")
+    @Schema(description = "첨부 파일 정보", requiredProperties = {"fileId", "fileUrl", "fileName", "fileExtension", "fileSize"})
     public record FileInfo(
 
             @Schema(description = "파일 ID", example = "1")
@@ -69,13 +70,13 @@ public record MemoDetailResponse(
             @Schema(description = "파일 다운로드 URL (Presigned URL)")
             String fileUrl,
 
-            @Schema(description = "파일명", example = "SOPT_7th_seminar.pdf")
+            @Schema(description = "파일명", example = "SOPT_7th_seminar.pdf", nullable = true)
             String fileName,
 
-            @Schema(description = "파일 확장자", example = "pdf")
+            @Schema(description = "파일 확장자", example = "pdf", nullable = true)
             String fileExtension,
 
-            @Schema(description = "파일 크기", example = "1.00GB")
+            @Schema(description = "파일 크기", example = "1.00GB", nullable = true)
             String fileSize
     ) {}
 

--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -51,13 +51,13 @@ public record MemoDetailResponse(
             @Schema(description = "이미지 URL (Presigned URL)")
             String imageUrl,
 
-            @Schema(description = "이미지 파일명", example = "seminar_slide.png", nullable = true)
+            @Schema(description = "이미지 파일명. 저장된 파일명 정보가 없는 경우 null", example = "seminar_slide.png", nullable = true)
             String imageName,
 
-            @Schema(description = "이미지 확장자", example = "png", nullable = true)
+            @Schema(description = "이미지 확장자. 저장된 확장자 정보가 없는 경우 null", example = "png", nullable = true)
             String imageExtension,
 
-            @Schema(description = "이미지 크기", example = "0.24MB", nullable = true)
+            @Schema(description = "이미지 크기. 저장된 파일 크기 정보가 없는 경우 null", example = "0.24MB", nullable = true)
             String imageSize
     ) {}
 
@@ -70,13 +70,13 @@ public record MemoDetailResponse(
             @Schema(description = "파일 다운로드 URL (Presigned URL)")
             String fileUrl,
 
-            @Schema(description = "파일명", example = "SOPT_7th_seminar.pdf", nullable = true)
+            @Schema(description = "파일명. 저장된 파일명 정보가 없는 경우 null", example = "SOPT_7th_seminar.pdf", nullable = true)
             String fileName,
 
-            @Schema(description = "파일 확장자", example = "pdf", nullable = true)
+            @Schema(description = "파일 확장자. 저장된 확장자 정보가 없는 경우 null", example = "pdf", nullable = true)
             String fileExtension,
 
-            @Schema(description = "파일 크기", example = "1.00GB", nullable = true)
+            @Schema(description = "파일 크기. 저장된 파일 크기 정보가 없는 경우 null", example = "1.00GB", nullable = true)
             String fileSize
     ) {}
 

--- a/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoListDashboardResponse.java
@@ -1,5 +1,6 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.tag.entity.Tag;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoTag;
@@ -8,6 +9,7 @@ import org.project.global.util.MemoContentUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(requiredProperties = {"totalCount", "memos"})
 public record MemoListDashboardResponse(
         long totalCount,
         List<MemoDashboardResponse> memos
@@ -21,12 +23,14 @@ public record MemoListDashboardResponse(
     /**
      * 대시보드용 메모 응답
      */
+    @Schema(requiredProperties = {"memoId", "title", "content", "representativeImageUrl", "imageCount", "fileCount", "isPinned", "isAiGenerated", "isNew", "createdAt", "tagList"})
     public record MemoDashboardResponse(
             Long memoId,
             String title,
             String content,
 
             // 대표 이미지 (priority 가장 낮은 1개, presigned URL)
+            @Schema(nullable = true)
             String representativeImageUrl,
 
             // 이미지 / 파일 개수
@@ -74,6 +78,7 @@ public record MemoListDashboardResponse(
     /**
      * 태그 응답
      */
+    @Schema(requiredProperties = {"tagId", "name", "color"})
     public record TagResponse(
             Long tagId,
             String name,

--- a/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
@@ -1,13 +1,16 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(requiredProperties = {"images", "files"})
 public record MemoPresignedUrlResponse(
 
         List<PresignedUrlResponse> images,
         List<PresignedUrlResponse> files
 ) {
 
+    @Schema(requiredProperties = {"s3Key", "presignedUrl", "bytes", "extension", "priority"})
     public record PresignedUrlResponse(
             String s3Key,
             String presignedUrl,

--- a/src/main/java/org/project/domain/memo/dto/response/MemoRecommendationItemResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoRecommendationItemResponse.java
@@ -1,7 +1,9 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.memo.entity.Memo;
 
+@Schema(requiredProperties = {"memoId", "title"})
 public record MemoRecommendationItemResponse(
         Long memoId,
         String title

--- a/src/main/java/org/project/domain/memo/dto/response/MemoRecommendationResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoRecommendationResponse.java
@@ -1,9 +1,12 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(requiredProperties = {"results", "message"})
 public record MemoRecommendationResponse(
         List<MemoRecommendationItemResponse> results,
+        @Schema(nullable = true)
         String message
 ) {
     public static MemoRecommendationResponse of(List<MemoRecommendationItemResponse> results) {

--- a/src/main/java/org/project/domain/memo/dto/response/MemoResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoResponse.java
@@ -5,6 +5,7 @@ import org.project.domain.memo.entity.Memo;
 
 import java.time.LocalDateTime;
 
+@Schema(requiredProperties = {"memoId", "title", "createdAt"})
 public record MemoResponse (
         @Schema(description = "메모 ID", example = "1")
         Long memoId,

--- a/src/main/java/org/project/domain/memo/dto/response/MemoSearchItemResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoSearchItemResponse.java
@@ -1,5 +1,6 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoTag;
 import org.project.global.util.MarkdownUtil;
@@ -8,6 +9,7 @@ import org.project.global.util.MemoContentUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(requiredProperties = {"memoId", "title", "content", "tagList", "createdAt", "searchType"})
 public record MemoSearchItemResponse(
         Long memoId,
         String title,

--- a/src/main/java/org/project/domain/memo/dto/response/MemoSearchResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoSearchResponse.java
@@ -1,9 +1,12 @@
 package org.project.domain.memo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(requiredProperties = {"results", "message"})
 public record MemoSearchResponse(
         List<MemoSearchItemResponse> results,
+        @Schema(nullable = true)
         String message
 ) {
     public static MemoSearchResponse of(List<MemoSearchItemResponse> results, String message) {

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureListResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(requiredProperties = "memos")
 public record MemoStructureListResponse(
         @Schema(description = "구조화뷰 메모 목록")
         List<MemoStructureResponse> memos

--- a/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoStructureResponse.java
@@ -7,6 +7,7 @@ import org.project.global.util.MemoContentUtils;
 
 import java.util.List;
 
+@Schema(requiredProperties = {"memoId", "title", "content", "tagList"})
 public record MemoStructureResponse(
         @Schema(description = "메모 ID", example = "1")
         Long memoId,

--- a/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagHierarchyResponse.java
@@ -1,10 +1,12 @@
 package org.project.domain.tag.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.tag.entity.Tag;
 
 import java.util.List;
 import java.util.Map;
 
+@Schema(requiredProperties = {"parentTag", "childTags"})
 public record TagHierarchyResponse(
         TagSummaryResponse parentTag,
         List<TagTreeResponse> childTags
@@ -21,10 +23,12 @@ public record TagHierarchyResponse(
         );
     }
 
+    @Schema(requiredProperties = {"tagId", "name", "color", "parentId", "childTags"})
     public record TagTreeResponse(
             Long tagId,
             String name,
             String color,
+            @Schema(nullable = true)
             Long parentId,
             List<TagTreeResponse> childTags
     ) {

--- a/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagListResponse.java
@@ -1,8 +1,10 @@
 package org.project.domain.tag.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.tag.entity.Tag;
 import java.util.List;
 
+@Schema(requiredProperties = "tags")
 public record TagListResponse(
         List<TagResponse> tags
 ) {
@@ -15,10 +17,12 @@ public record TagListResponse(
         );
     }
 
+    @Schema(requiredProperties = {"tagId", "name", "color", "parentId"})
     public record TagResponse(
             Long tagId,
             String name,
             String color,
+            @Schema(nullable = true)
             Long parentId
     ) {
         public static TagResponse from(Tag tag) {

--- a/src/main/java/org/project/domain/tag/dto/response/TagParentListResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagParentListResponse.java
@@ -1,9 +1,11 @@
 package org.project.domain.tag.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.tag.entity.Tag;
 
 import java.util.List;
 
+@Schema(requiredProperties = "tags")
 public record TagParentListResponse(
         List<TagSummaryResponse> tags
 ) {

--- a/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
+++ b/src/main/java/org/project/domain/tag/dto/response/TagSummaryResponse.java
@@ -1,11 +1,14 @@
 package org.project.domain.tag.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.tag.entity.Tag;
 
+@Schema(requiredProperties = {"tagId", "name", "color", "parentId"})
 public record TagSummaryResponse(
         Long tagId,
         String name,
         String color,
+        @Schema(nullable = true)
         Long parentId
 ) {
     public static TagSummaryResponse from(Tag tag) {

--- a/src/main/java/org/project/domain/user/dto/response/JwtLoginResponse.java
+++ b/src/main/java/org/project/domain/user/dto/response/JwtLoginResponse.java
@@ -1,13 +1,16 @@
 package org.project.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.user.entity.User;
 
+@Schema(requiredProperties = {"accessToken", "refreshToken", "name", "profileImageUrl"})
 public record JwtLoginResponse(
         String accessToken,
         String refreshToken,
 //        boolean isRegistered,   // DB 저장된 등록 완료 여부
 //        boolean isNewUser,      // 소셜 최초 로그인 여부
         String name,
+        @Schema(nullable = true)
         String profileImageUrl
 ) {
 

--- a/src/main/java/org/project/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/project/domain/user/dto/response/UserInfoResponse.java
@@ -1,11 +1,14 @@
 package org.project.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.domain.user.entity.User;
 
+@Schema(requiredProperties = {"userId", "name", "email", "profileImageUrl"})
 public record UserInfoResponse(
         Long userId,
         String name,
         String email,
+        @Schema(nullable = true)
         String profileImageUrl
 ) {
 

--- a/src/main/java/org/project/global/response/ApiResponse.java
+++ b/src/main/java/org/project/global/response/ApiResponse.java
@@ -1,9 +1,11 @@
 package org.project.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(requiredProperties = {"code", "msg"})
 public record ApiResponse<T>(int code, String msg, T data) {
 
     public static <T> ApiResponse<T> ok(T data, String msg) {

--- a/src/test/java/org/project/domain/ai/dto/response/ReEmbeddingResultResponseSchemaTest.java
+++ b/src/test/java/org/project/domain/ai/dto/response/ReEmbeddingResultResponseSchemaTest.java
@@ -1,0 +1,37 @@
+package org.project.domain.ai.dto.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.Test;
+import org.project.global.response.ApiResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReEmbeddingResultResponseSchemaTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void nullable_필드는_null이어도_응답에서_생략되지_않는다() throws Exception {
+        ReEmbeddingResultResponse result = new ReEmbeddingResultResponse(1L, true, null, null);
+
+        String json = objectMapper.writeValueAsString(ApiResponse.ok(result));
+
+        assertThat(json)
+                .contains("\"imageSucceeded\":null")
+                .contains("\"fileSucceeded\":null");
+    }
+
+    @Test
+    void 재임베딩_결과_스키마는_모든_필드를_required로_명시하고_첨부결과만_nullable로_명시한다() {
+        Schema<?> schema = ModelConverters.getInstance()
+                .readAllAsResolvedSchema(new io.swagger.v3.core.converter.AnnotatedType(ReEmbeddingResultResponse.class))
+                .schema;
+
+        assertThat(schema.getRequired())
+                .containsExactlyInAnyOrder("memoId", "textSucceeded", "imageSucceeded", "fileSucceeded");
+        assertThat(schema.getProperties().get("imageSucceeded").getNullable()).isTrue();
+        assertThat(schema.getProperties().get("fileSucceeded").getNullable()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #167 

## 📝 Summary

- 응답 DTO 및 중첩 응답 DTO의 항상 포함되는 필드를 OpenAPI required로 명시했습니다.
- 값은 null일 수 있지만 필드는 항상 포함되는 경우 nullable: true로 명시했습니다.
- ApiResponse의 code, msg를 required로 명시했습니다.
  - data는 오류 응답에서 실제로 생략될 수 있어 required로 지정하지 않았습니다.
- nullable 필드가 null일 때 실제 JSON 응답에서 누락되지 않는지, OpenAPI 스키마가 의도대로 생성되는지 테스트를 추가했습니다.


## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Swagger/OpenAPI 응답 스키마에 필수 속성과 nullable 필드 정보가 추가되었습니다.
  * AI 평가, 채팅방, 메모, 태그, 사용자 및 공통 API 응답 문서가 더욱 정확해졌습니다.
  * 이미지·첨부 파일·프로필 이미지 등 선택 가능한 필드가 명확히 표시됩니다.

* **테스트**
  * 재임베딩 응답의 nullable 필드 직렬화 및 OpenAPI 스키마 정의를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->