### PR TITLE
[CHORE] S3 업로드 실제 용량 검증 및 미참조 객체 정리

### DIFF
--- a/src/main/java/org/project/MainApplication.java
+++ b/src/main/java/org/project/MainApplication.java
@@ -2,8 +2,10 @@ package org.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MainApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoFileRepository.java
@@ -13,6 +13,9 @@ public interface MemoFileRepository extends JpaRepository<MemoFile, Long>, MemoF
 
     List<MemoFile> findByMemoIdIn(List<Long> memoIds);
 
+    @Query("select mf.fileS3Key from MemoFile mf join mf.memo m where m.isDeleted = false")
+    List<String> findAllFileS3Keys();
+
     @Modifying
     @Query("DELETE FROM MemoFile mf WHERE mf.memo = :memo")
     void deleteByMemo(@Param("memo") Memo memo);

--- a/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoImageRepository.java
@@ -13,6 +13,9 @@ public interface MemoImageRepository extends JpaRepository<MemoImage, Long>, Mem
 
     List<MemoImage> findByMemoIdIn(List<Long> memoIds);
 
+    @Query("select mi.imageS3Key from MemoImage mi join mi.memo m where m.isDeleted = false")
+    List<String> findAllImageS3Keys();
+
     @Modifying
     @Query("DELETE FROM MemoImage mi WHERE mi.memo = :memo")
     void deleteByMemo(@Param("memo") Memo memo);

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -125,8 +126,7 @@ public class MemoServiceImpl implements MemoService {
 
         validateImageCount(request.images());
         validateFileCount(request.files());
-        validateBytes(request.images(), MemoCreateRequest.ImageRequest::bytes, MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE);
-        validateBytes(request.files(), MemoCreateRequest.FileRequest::bytes, MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE);
+        Map<String, Long> actualBytesByKey = validateUploadedMedia(userId, request);
 
         // 메모 생성
         Memo memo = Memo.createMemo(
@@ -149,10 +149,10 @@ public class MemoServiceImpl implements MemoService {
         );
 
         // 이미지 메타데이터 저장 (optional)
-        saveMemoImages(savedMemo, request.images(), userId);
+        saveMemoImages(savedMemo, request.images(), userId, actualBytesByKey);
 
         // 파일 메타데이터 저장 (optional)
-        saveMemoFiles(savedMemo, request.files(), userId);
+        saveMemoFiles(savedMemo, request.files(), userId, actualBytesByKey);
 
         return MemoResponse.from(savedMemo);
     }
@@ -559,13 +559,18 @@ public class MemoServiceImpl implements MemoService {
         return List.of(commonTag);
     }
 
-    private void saveMemoImages(Memo memo, List<MemoCreateRequest.ImageRequest> images, Long userId) {
+    private void saveMemoImages(
+            Memo memo,
+            List<MemoCreateRequest.ImageRequest> images,
+            Long userId,
+            Map<String, Long> actualBytesByKey
+    ) {
         if (images == null || images.isEmpty()) {
             return;
         }
 
         List<MemoImage> memoImages = images.stream()
-                .map(r -> createMemoImage(memo, r, userId))
+                .map(r -> createMemoImage(memo, r, userId, actualBytesByKey.get(r.s3Key())))
                 .toList();
 
         memoImageRepository.saveAll(memoImages);
@@ -581,26 +586,34 @@ public class MemoServiceImpl implements MemoService {
         );
     }
 
-    private MemoImage createMemoImage(Memo memo, MemoCreateRequest.ImageRequest request, Long userId) {
-        s3KeyUtil.validateS3KeyOwner(userId, request.s3Key());
-
+    private MemoImage createMemoImage(
+            Memo memo,
+            MemoCreateRequest.ImageRequest request,
+            Long userId,
+            Long actualBytes
+    ) {
         return MemoImage.builder()
                 .memo(memo)
                 .imageS3Key(request.s3Key())
                 .imageName(request.imageName())
-                .imageBytes(request.bytes())
+                .imageBytes(actualBytes)
                 .imageExtension(request.extension())
                 .imagePriority(request.priority())
                 .build();
     }
 
-    private void saveMemoFiles(Memo memo, List<MemoCreateRequest.FileRequest> files, Long userId) {
+    private void saveMemoFiles(
+            Memo memo,
+            List<MemoCreateRequest.FileRequest> files,
+            Long userId,
+            Map<String, Long> actualBytesByKey
+    ) {
         if (files == null || files.isEmpty()) {
             return;
         }
 
         List<MemoFile> memoFiles = files.stream()
-                .map(r -> createMemoFile(memo, r, userId))
+                .map(r -> createMemoFile(memo, r, userId, actualBytesByKey.get(r.s3Key())))
                 .toList();
 
         memoFileRepository.saveAll(memoFiles);
@@ -616,14 +629,17 @@ public class MemoServiceImpl implements MemoService {
         );
     }
 
-    private MemoFile createMemoFile(Memo memo, MemoCreateRequest.FileRequest request, Long userId) {
-        s3KeyUtil.validateS3KeyOwner(userId, request.s3Key());
-
+    private MemoFile createMemoFile(
+            Memo memo,
+            MemoCreateRequest.FileRequest request,
+            Long userId,
+            Long actualBytes
+    ) {
         return MemoFile.builder()
                 .memo(memo)
                 .fileS3Key(request.s3Key())
                 .fileName(request.fileName())
-                .fileBytes(request.bytes())
+                .fileBytes(actualBytes)
                 .fileExtension(request.extension())
                 .filePriority(request.priority())
                 .build();
@@ -684,6 +700,52 @@ public class MemoServiceImpl implements MemoService {
         if (files != null && files.size() > MAX_FILE_COUNT) {
             throw new MemoException(MemoErrorCode.TOO_MANY_FILES);
         }
+    }
+
+    private Map<String, Long> validateUploadedMedia(Long userId, MemoCreateRequest request) {
+        List<CompletableFuture<UploadedMedia>> validations = new ArrayList<>();
+
+        if (request.images() != null) {
+            request.images().forEach(image -> validations.add(CompletableFuture.supplyAsync(
+                    () -> validateUploadedMedia(userId, "memo-image", image.s3Key(), MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE),
+                    ioExecutor
+            )));
+        }
+        if (request.files() != null) {
+            request.files().forEach(file -> validations.add(CompletableFuture.supplyAsync(
+                    () -> validateUploadedMedia(userId, "memo-file", file.s3Key(), MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE),
+                    ioExecutor
+            )));
+        }
+
+        try {
+            return validations.stream()
+                    .map(CompletableFuture::join)
+                    .collect(Collectors.toMap(UploadedMedia::s3Key, UploadedMedia::bytes, (first, ignored) -> first));
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw e;
+        }
+    }
+
+    private UploadedMedia validateUploadedMedia(
+            Long userId,
+            String prefix,
+            String s3Key,
+            long maxBytes,
+            MemoErrorCode errorCode
+    ) {
+        s3KeyUtil.validateS3Key(userId, prefix, s3Key);
+        long actualBytes = s3Util.getObjectMetadata(s3Key).contentLength();
+        if (actualBytes > maxBytes) {
+            throw new MemoException(errorCode);
+        }
+        return new UploadedMedia(s3Key, actualBytes);
+    }
+
+    private record UploadedMedia(String s3Key, long bytes) {
     }
 
     private <T> void validateBytes(

--- a/src/main/java/org/project/domain/s3/S3OrphanFileCleanupScheduler.java
+++ b/src/main/java/org/project/domain/s3/S3OrphanFileCleanupScheduler.java
@@ -1,0 +1,50 @@
+package org.project.domain.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.domain.memo.repository.MemoFileRepository;
+import org.project.domain.memo.repository.MemoImageRepository;
+import org.project.global.util.S3Util;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3OrphanFileCleanupScheduler {
+
+    private static final Duration ORPHAN_GRACE_PERIOD = Duration.ofMinutes(10);
+    private static final List<String> MANAGED_PREFIXES = List.of("memo-image/", "memo-file/");
+
+    private final S3Util s3Util;
+    private final MemoImageRepository memoImageRepository;
+    private final MemoFileRepository memoFileRepository;
+
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void deleteOrphanFiles() {
+        Set<String> referencedKeys = new HashSet<>(memoImageRepository.findAllImageS3Keys());
+        referencedKeys.addAll(memoFileRepository.findAllFileS3Keys());
+        Instant cutoff = Instant.now().minus(ORPHAN_GRACE_PERIOD);
+
+        MANAGED_PREFIXES.stream()
+                .flatMap(prefix -> s3Util.listObjects(prefix).stream())
+                .filter(object -> !referencedKeys.contains(object.key()))
+                .filter(object -> object.lastModified() != null && object.lastModified().isBefore(cutoff))
+                .forEach(object -> deleteOrLog(object.key()));
+    }
+
+    private void deleteOrLog(String key) {
+        try {
+            s3Util.deleteFile(key);
+            log.info("미참조 S3 객체 삭제 성공 - Key: {}", key);
+        } catch (RuntimeException e) {
+            log.error("미참조 S3 객체 삭제 실패 - Key: {}", key, e);
+        }
+    }
+}

--- a/src/main/java/org/project/global/util/S3KeyUtil.java
+++ b/src/main/java/org/project/global/util/S3KeyUtil.java
@@ -35,4 +35,12 @@ public class S3KeyUtil {
             throw new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH);
         }
     }
+
+    public void validateS3Key(Long requestUserId, String prefix, String s3Key) {
+        validateS3KeyOwner(requestUserId, s3Key);
+
+        if (!s3Key.startsWith(prefix + "/" + requestUserId + "/")) {
+            throw new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+    }
 }

--- a/src/main/java/org/project/global/util/S3Util.java
+++ b/src/main/java/org/project/global/util/S3Util.java
@@ -18,6 +18,8 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -95,6 +97,52 @@ public class S3Util {
             log.error("파일 삭제 중 예상치 못한 에러 - Key: {}", key, e);
             throw new S3CustomException(S3ErrorCode.FILE_DELETE_FAILED);
         }
+    }
+
+    /**
+     * S3 객체 본문을 내려받지 않고 업로드 검증에 필요한 메타데이터를 조회한다.
+     */
+    public S3ObjectMetadata getObjectMetadata(String key) {
+        try {
+            HeadObjectResponse response = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+
+            return new S3ObjectMetadata(response.contentLength(), response.contentType());
+        } catch (NoSuchKeyException e) {
+            throw new S3CustomException(S3ErrorCode.FILE_NOT_FOUND);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                throw new S3CustomException(S3ErrorCode.FILE_NOT_FOUND);
+            }
+            log.error("S3 객체 메타데이터 조회 실패 - Key: {}, ErrorCode: {}", key, e.awsErrorDetails().errorCode(), e);
+            throw new S3CustomException(S3ErrorCode.FILE_DOWNLOAD_FAILED);
+        }
+    }
+
+    /**
+     * prefix 아래 객체를 모두 조회한다. 고아 객체 정리 용도이며 객체 본문은 조회하지 않는다.
+     */
+    public List<S3Object> listObjects(String prefix) {
+        try {
+            List<S3Object> objects = new ArrayList<>();
+            ListObjectsV2Request request = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(prefix)
+                    .build();
+
+            for (ListObjectsV2Response page : s3Client.listObjectsV2Paginator(request)) {
+                objects.addAll(page.contents());
+            }
+            return objects;
+        } catch (S3Exception e) {
+            log.error("S3 객체 목록 조회 실패 - Prefix: {}, ErrorCode: {}", prefix, e.awsErrorDetails().errorCode(), e);
+            throw new S3CustomException(S3ErrorCode.FILE_DOWNLOAD_FAILED);
+        }
+    }
+
+    public record S3ObjectMetadata(long contentLength, String contentType) {
     }
 
     /**

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -90,6 +91,10 @@ class MemoServiceImplTest {
 
         @BeforeEach
         void setUp() {
+            ReflectionTestUtils.setField(memoService, "ioExecutor", (Executor) Runnable::run);
+            lenient().when(s3Util.getObjectMetadata(anyString()))
+                    .thenReturn(new S3Util.S3ObjectMetadata(1_024L, "application/octet-stream"));
+
             // 사용자 더미
             user = User.builder()
                     .id(1L)
@@ -181,14 +186,15 @@ class MemoServiceImplTest {
         }
 
         @Test
-        @DisplayName("파일 용량이 제한을 초과하면 예외가 발생한다.")
+        @DisplayName("S3 실제 파일 용량이 제한을 초과하면 예외가 발생한다.")
         void createMemo_FileTooLarge() {
             given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
-            long overLimit = 10L * 1024 * 1024 + 1;
             List<MemoCreateRequest.FileRequest> files = List.of(
-                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", overLimit, "pdf", 1)
+                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", 1L, "pdf", 1)
             );
+            given(s3Util.getObjectMetadata("memo-file/1/1.pdf"))
+                    .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
 
             MemoCreateRequest tooLargeFileRequest = new MemoCreateRequest(
                     "제목",
@@ -296,26 +302,43 @@ class MemoServiceImplTest {
             when(userRepository.findById(userId))
                     .thenReturn(Optional.of(user));
 
-            // memo save는 호출되지만
-            when(memoRepository.save(any(Memo.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
             // S3Key 검증 실패 강제
             doThrow(new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH))
                     .when(s3KeyUtil)
-                    .validateS3KeyOwner(eq(userId), anyString());
+                    .validateS3Key(eq(userId), eq("memo-image"), anyString());
 
             // when & then
             assertThatThrownBy(() -> memoService.createMemo(userId, request))
                     .isInstanceOf(MemoException.class)
                     .hasMessage(MemoErrorCode.S3_KEY_USER_MISMATCH.getMsg());
 
-            // 메모 저장은 시도됨
-            verify(memoRepository, times(1)).save(any(Memo.class));
+            // S3 검증이 선행되므로 메모는 저장되지 않음
+            verify(memoRepository, never()).save(any());
 
             // 이미지/파일 저장 로직은 중단됨
             verify(memoImageRepository, never()).saveAll(any());
             verify(memoFileRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("요청 bytes가 아닌 S3 실제 크기를 저장한다")
+        void createMemo_savesActualS3ObjectSize() {
+            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+            when(memoRepository.save(any(Memo.class))).thenAnswer(invocation -> invocation.getArgument(0));
+            given(s3Util.getObjectMetadata("memo-image/1/test.png"))
+                    .willReturn(new S3Util.S3ObjectMetadata(3_000L, "image/png"));
+            given(s3Util.getObjectMetadata("memo-file/1/test.pdf"))
+                    .willReturn(new S3Util.S3ObjectMetadata(4_000L, "application/pdf"));
+
+            memoService.createMemo(user.getId(), request);
+
+            ArgumentCaptor<List<MemoImage>> imageCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<List<MemoFile>> fileCaptor = ArgumentCaptor.forClass(List.class);
+            verify(memoImageRepository).saveAll(imageCaptor.capture());
+            verify(memoFileRepository).saveAll(fileCaptor.capture());
+
+            assertThat(imageCaptor.getValue().get(0).getImageBytes()).isEqualTo(3_000L);
+            assertThat(fileCaptor.getValue().get(0).getFileBytes()).isEqualTo(4_000L);
         }
     }
 

--- a/src/test/java/org/project/domain/s3/S3OrphanFileCleanupSchedulerTest.java
+++ b/src/test/java/org/project/domain/s3/S3OrphanFileCleanupSchedulerTest.java
@@ -1,0 +1,49 @@
+package org.project.domain.s3;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.memo.repository.MemoFileRepository;
+import org.project.domain.memo.repository.MemoImageRepository;
+import org.project.global.util.S3Util;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class S3OrphanFileCleanupSchedulerTest {
+
+    @Mock private S3Util s3Util;
+    @Mock private MemoImageRepository memoImageRepository;
+    @Mock private MemoFileRepository memoFileRepository;
+
+    @Test
+    void deletesOnlyUnreferencedObjectsOlderThanGracePeriod() {
+        S3OrphanFileCleanupScheduler scheduler = new S3OrphanFileCleanupScheduler(
+                s3Util, memoImageRepository, memoFileRepository);
+        S3Object referenced = object("memo-image/1/referenced.png", Instant.now().minusSeconds(1_000));
+        S3Object orphan = object("memo-file/1/orphan.pdf", Instant.now().minusSeconds(1_000));
+        S3Object recent = object("memo-image/1/recent.png", Instant.now());
+
+        given(memoImageRepository.findAllImageS3Keys()).willReturn(List.of(referenced.key()));
+        given(memoFileRepository.findAllFileS3Keys()).willReturn(List.of());
+        given(s3Util.listObjects("memo-image/")).willReturn(List.of(referenced, recent));
+        given(s3Util.listObjects("memo-file/")).willReturn(List.of(orphan));
+
+        scheduler.deleteOrphanFiles();
+
+        verify(s3Util).deleteFile(orphan.key());
+        verify(s3Util, never()).deleteFile(referenced.key());
+        verify(s3Util, never()).deleteFile(recent.key());
+    }
+
+    private S3Object object(String key, Instant lastModified) {
+        return S3Object.builder().key(key).lastModified(lastModified).build();
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #170

## 📝 Summary

- 메모 생성 시 첨부 S3 객체의 `HeadObject`를 병렬 조회하여 실제 크기를 검증하도록 변경했습니다.
- 요청의 `bytes` 값 대신 S3의 실제 `contentLength`를 DB에 저장합니다.
- S3 key의 사용자 소유자 및 용도별 prefix를 검증합니다.
  - 이미지: `memo-image/{userId}/`
  - 파일: `memo-file/{userId}/`
- 매일 오전 4시(KST)에 미참조 S3 객체를 삭제하는 스케줄러를 추가했습니다.
  - 스케줄러 추가 이유 : 클라이언트에서 대용량 파일 업로드를 막더라도 서버단에서 2차 방어가 필요하다고 생각합니다.
  - S3 목록 pagination 처리
  - 업로드 직후 삭제 경쟁을 피하기 위한 10분 유예
  - 논리 삭제된 메모의 첨부 객체는 참조 키 조회에서 제외

## 🙏 Question & PR point

- 운영 IAM Role에 아래 S3 권한이 필요합니다.
  - `s3:GetObject`
  - `s3:ListBucket`
  - `s3:DeleteObject`
- 미참조 객체 정리 대상은 `memo-image/`, `memo-file/` prefix로 한정했습니다.

## 📬 Postman

- API endpoint 및 요청·응답 형식 변경 없음