### PR TITLE
[Feat] 메모 상세 조회 응답에 수정 시각 추가

### DIFF
--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -179,7 +179,7 @@ public class MemoController {
     }
 
     @GetMapping("/{memoId}")
-    @Operation(summary = "메모 전체 조회(모달창)", description = """
+    @Operation(summary = "메모 상세 조회", description = """
             하나의 메모를 상세조회 합니다.
             AI가 생성한 메모일 경우 선택한 메모의 ID를 리스트로 반환합니다.
             AI가 생성한 메모가 아닐 경우 선택한 메모가 없으므로 빈 리스트를 반환합니다.

--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
-@Schema(requiredProperties = {"memoId", "title", "content", "images", "files", "tagList", "createdAt", "isAiGenerated", "sourceMemoTitleList"})
+@Schema(requiredProperties = {"memoId", "title", "content", "images", "files", "tagList", "createdAt", "updatedAt", "isAiGenerated", "sourceMemoTitleList"})
 public record MemoDetailResponse(
 
         @Schema(description = "메모 ID", example = "1")
@@ -31,6 +31,9 @@ public record MemoDetailResponse(
 
         @Schema(description = "메모 생성 시각", example = "2026-01-13T10:30:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "메모 마지막 수정 시각", example = "2026-01-13T11:00:00")
+        LocalDateTime updatedAt,
 
         @Schema(description = "AI 생성 여부", example = "false")
         Boolean isAiGenerated,
@@ -99,6 +102,7 @@ public record MemoDetailResponse(
                         .map(MemoListDashboardResponse.TagResponse::from)
                         .toList(),
                 memo.getCreatedAt(),
+                memo.getUpdatedAt(),
                 memo.getIsAiGenerated(),
                 memo.getIsAiGenerated()
                         ? extractSourceTitles(sourceMemos)

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -1057,6 +1057,7 @@ class MemoControllerTest {
                             new MemoListDashboardResponse.TagResponse(3L, "레퍼런스", "purple")
                     ),
                     LocalDateTime.of(2026, 1, 16, 10, 30),
+                    LocalDateTime.of(2026, 1, 16, 11, 30),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
             );
@@ -1087,6 +1088,7 @@ class MemoControllerTest {
                     .andExpect(jsonPath("$.data.tagList[0].tagId").value(1L))
                     .andExpect(jsonPath("$.data.tagList[0].name").value("SOPT"))
                     .andExpect(jsonPath("$.data.tagList[0].color").value("light-blue"))
+                    .andExpect(jsonPath("$.data.updatedAt").value("2026-01-16T11:30:00"))
                     .andExpect(jsonPath("$.data.isAiGenerated").value(false))
                     .andExpect(jsonPath("$.data.sourceMemoTitleList").isArray())
                     .andExpect(jsonPath("$.data.sourceMemoTitleList.length()").value(0));
@@ -1111,6 +1113,7 @@ class MemoControllerTest {
                     List.of(),
                     List.of(new MemoListDashboardResponse.TagResponse(1L, "개인", "magenta")),
                     LocalDateTime.of(2026, 1, 16, 12, 0),
+                    LocalDateTime.of(2026, 1, 16, 12, 30),
                     false,  // AI 생성 아님
                     List.of()  // sourceList 비어있음
             );
@@ -1150,6 +1153,7 @@ class MemoControllerTest {
                     List.of(),  // 파일 없음
                     List.of(new MemoListDashboardResponse.TagResponse(1L, "메모", "pink")),
                     LocalDateTime.of(2026, 1, 16, 13, 0),
+                    LocalDateTime.of(2026, 1, 16, 13, 30),
                     false,
                     List.of()
             );

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -583,14 +583,16 @@ class MemoServiceImplTest {
     }
 
     @Nested
-    @DisplayName("메모 상세조회(모달창) 테스트")
+    @DisplayName("메모 상세조회 테스트")
     class getOneMemoDetail {
-        @DisplayName("메모 모달창을 상세 조회할 수 있어야 한다.")
+        @DisplayName("메모를 상세 조회할 수 있어야 한다.")
         @Test
         void getOneMemoDetail_Success() {
             // given 준비
             User user = User.builder().id(userId).build();
             Memo memo = Memo.createMemo("테스트 제목", "테스트 내용", user);
+            LocalDateTime updatedAt = LocalDateTime.of(2026, 8, 24, 10, 30);
+            ReflectionTestUtils.setField(memo, "updatedAt", updatedAt);
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             // when 실행
@@ -600,6 +602,7 @@ class MemoServiceImplTest {
             assertThat(response).isNotNull();
             assertThat(response.title()).isEqualTo("테스트 제목");
             assertThat(response.content()).isEqualTo("테스트 내용");
+            assertThat(response.updatedAt()).isEqualTo(updatedAt);
             verify(memoRepository, times(1)).findByIdAndNotDeleted(memoId);
         }
 


### PR DESCRIPTION
## 📣 Related Issue

- close #173 

## 📝 Summary

- 메모 상세 조회 응답에 `updatedAt` 필드를 추가했습니다.
- `Memo`의 감사 필드 `updatedAt`을 상세 응답 DTO에 매핑했습니다.
- Swagger API 요약에서 모달 관련 문구를 제거했습니다.
- 메모 상세 조회의 `updatedAt` 응답 및 매핑 테스트를 추가했습니다.

## 🙏 Question & PR point

- `updatedAt`은 `BaseEntity`의 `@LastModifiedDate` 값을 사용합니다.
- 메모가 수정되면 마지막 수정 시각이 상세 조회 응답에 함께 반환됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 메모 상세 조회 응답에 최종 수정 시각(`updatedAt`)이 추가되었습니다.
  - Swagger 문서에 메모 상세 조회의 수정 시각 정보가 표시됩니다.

- **문서**
  - API 요약 문구가 ‘메모 전체 조회(모달창)’에서 ‘메모 상세 조회’로 명확하게 변경되었습니다.

- **테스트**
  - 메모 상세 조회 시 수정 시각이 정확히 반환되는지 검증이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->