### PR TITLE
[Hotfix] 폴백로직 서버단에서 처리

### DIFF
--- a/src/main/java/org/project/domain/memo/controller/MemoController.java
+++ b/src/main/java/org/project/domain/memo/controller/MemoController.java
@@ -231,7 +231,9 @@ public class MemoController {
     @GetMapping("/recent-viewed")
     @Operation(summary = "최근 열람한 메모", description = """
             검색 모달 [입력 완료 전] 화면용. 사용자가 최근에 열람한 메모를 최신 열람순으로 반환합니다.
-            (열람 = 메모 상세조회. 한 번도 열람하지 않은 메모는 포함되지 않습니다.)
+            (열람 = 메모 상세조회.)
+            열람 이력이 하나도 없으면 최근 생성 메모(생성 최신순)로 폴백합니다.
+            목록 출처는 data.source로 구분합니다. RECENT_VIEWED / RECENT_CREATED
             """)
     public ResponseEntity<ApiResponse<MemoRecentViewedResponse>> getRecentViewedMemos(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/org/project/domain/memo/dto/response/MemoRecentViewedResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoRecentViewedResponse.java
@@ -12,23 +12,37 @@ import java.util.List;
 /**
  * 검색 모달 [입력 완료 전] 화면의 "최근 열람한 메모" 목록 응답.
  * 최근 열람순(lastViewedAt DESC)으로 정렬된 카드 리스트를 담는다.
+ * 열람 이력이 하나도 없으면 서버가 최근 생성 메모(createdAt DESC)로 폴백해 채운다.
  */
-@Schema(requiredProperties = {"results"})
+@Schema(requiredProperties = {"source", "results"})
 public record MemoRecentViewedResponse(
+        @Schema(
+                description = "목록 출처. RECENT_VIEWED=최근 열람 메모, RECENT_CREATED=열람 이력이 없어 최근 생성 메모로 폴백. "
+        )
+        RecentViewedSource source,
         List<Item> results
 ) {
-    public static MemoRecentViewedResponse of(List<Item> results) {
-        return new MemoRecentViewedResponse(results);
+    public static MemoRecentViewedResponse of(RecentViewedSource source, List<Item> results) {
+        return new MemoRecentViewedResponse(source, results);
     }
 
-    @Schema(requiredProperties = {"memoId", "title", "content", "tagList", "lastViewedAt"})
+    @Schema(requiredProperties = {"memoId", "title", "content", "tagList", "createdAt"})
     public record Item(
             Long memoId,
             String title,
             String content,
             List<MemoListDashboardResponse.TagResponse> tagList,
-            // 마지막 열람 시각(카드 날짜 표기용). 최근 열람 목록이므로 항상 값이 존재한다.
-            LocalDateTime lastViewedAt
+            // 마지막 열람 시각. 최근 열람 아이템이면 값이 있고, 최근 생성 폴백 아이템이면 null이다.
+            // 값이 null이면 클라이언트는 폴백(최근 생성)으로 보고 createdAt으로 날짜를 표기한다.
+            @Schema(
+                    nullable = true,
+                    description = "마지막 열람 시각. null이면 열람 이력이 없어 최근 생성 메모로 폴백된 아이템이라는 뜻이며, "
+                            + "이 경우 클라이언트는 createdAt으로 날짜를 표기한다. null이 아니면 실제 최근 열람 메모다."
+            )
+            LocalDateTime lastViewedAt,
+            // 생성 시각(카드 날짜 표기용 폴백). 항상 값이 존재한다.
+            @Schema(description = "생성 시각. 항상 존재하며, 폴백(lastViewedAt=null) 아이템의 날짜 표기에 사용한다.")
+            LocalDateTime createdAt
     ) {
         public static Item from(Memo memo) {
             return new Item(
@@ -39,7 +53,8 @@ public record MemoRecentViewedResponse(
                             .map(MemoTag::getTag)
                             .map(MemoListDashboardResponse.TagResponse::from)
                             .toList(),
-                    memo.getLastViewedAt()
+                    memo.getLastViewedAt(),
+                    memo.getCreatedAt()
             );
         }
     }

--- a/src/main/java/org/project/domain/memo/dto/response/RecentViewedSource.java
+++ b/src/main/java/org/project/domain/memo/dto/response/RecentViewedSource.java
@@ -1,0 +1,6 @@
+package org.project.domain.memo.dto.response;
+
+public enum RecentViewedSource {
+    RECENT_VIEWED,
+    RECENT_CREATED
+}

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryCustom.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryCustom.java
@@ -26,4 +26,6 @@ public interface MemoRepositoryCustom {
     List<Memo> searchByText(Long userId, String query);
 
     List<Memo> findRecentViewed(Long userId, int limit);
+
+    List<Memo> findRecentCreated(Long userId, int limit);
 }

--- a/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
+++ b/src/main/java/org/project/domain/memo/repository/MemoRepositoryImpl.java
@@ -233,6 +233,39 @@ public class MemoRepositoryImpl implements MemoRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<Memo> findRecentCreated(Long userId, int limit) {
+        QMemo memo = QMemo.memo;
+        QMemoTag memoTag = QMemoTag.memoTag;
+        QTag tag = QTag.tag;
+
+        // 최근 열람 메모가 없을 때의 폴백 — 열람 여부와 무관하게 생성 최신순으로 상위 limit개.
+        // 컬렉션 fetchJoin + limit의 인메모리 페이징을 피하려고 id 먼저 조회 후 페치조인(findRecentViewed와 동일 패턴).
+        List<Long> memoIds = queryFactory
+                .select(memo.id)
+                .from(memo)
+                .where(
+                        memo.user.id.eq(userId),
+                        memo.isDeleted.eq(false)
+                )
+                .orderBy(memo.createdAt.desc(), memo.id.desc())
+                .limit(limit)
+                .fetch();
+
+        if (memoIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .selectDistinct(memo)
+                .from(memo)
+                .leftJoin(memo.memoTags, memoTag).fetchJoin()
+                .leftJoin(memoTag.tag, tag).fetchJoin()
+                .where(memo.id.in(memoIds))
+                .orderBy(memo.createdAt.desc(), memo.id.desc())
+                .fetch();
+    }
+
     /**
      * tagIds가 있을 때
      */

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -441,14 +441,21 @@ public class MemoServiceImpl implements MemoService {
     @Override
     public MemoRecentViewedResponse getRecentViewedMemos(Long userId) {
         // 검색 모달 [입력 완료 전] — 최근 열람한 메모를 최신 열람순으로 상위 N개 반환.
-        List<Memo> memos = memoRepository.findRecentViewed(
-                userId, memoSearchProperties.getRecentViewedLimit());
+        int limit = memoSearchProperties.getRecentViewedLimit();
+        List<Memo> memos = memoRepository.findRecentViewed(userId, limit);
+
+        // 열람 이력이 하나도 없으면 검색 진입 화면이 비지 않도록 최근 생성 메모로 폴백한다.
+        RecentViewedSource source = RecentViewedSource.RECENT_VIEWED;
+        if (memos.isEmpty()) {
+            source = RecentViewedSource.RECENT_CREATED;
+            memos = memoRepository.findRecentCreated(userId, limit);
+        }
 
         List<MemoRecentViewedResponse.Item> items = memos.stream()
                 .map(MemoRecentViewedResponse.Item::from)
                 .toList();
 
-        return MemoRecentViewedResponse.of(items);
+        return MemoRecentViewedResponse.of(source, items);
     }
 
     @Override

--- a/src/test/java/org/project/domain/memo/repository/MemoRepositoryImplTest.java
+++ b/src/test/java/org/project/domain/memo/repository/MemoRepositoryImplTest.java
@@ -222,4 +222,90 @@ class MemoRepositoryImplTest {
         // then
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("최근 생성 메모를 열람 여부와 무관하게 생성 최신순으로 조회한다")
+    void findRecentCreated_orderByCreatedAtDesc() {
+        // given
+        User user = userRepository.save(
+                User.createSocialUser("created@test.com", "유저", "profile.png", "google")
+        );
+
+        LocalDateTime base = LocalDateTime.now();
+        Memo oldMemo = Memo.createMemo("old", "old", user);
+        Memo newMemo = Memo.createMemo("new", "new", user);
+        em.persist(oldMemo);
+        em.persist(newMemo);
+        em.flush();
+
+        forceCreatedAt(oldMemo.getId(), base.minusMinutes(1));
+        forceCreatedAt(newMemo.getId(), base);
+        em.clear();
+
+        // when
+        List<Memo> result = memoRepository.findRecentCreated(user.getId(), 6);
+
+        // then — 열람 이력이 없어도(lastViewedAt == null) 최신 생성순으로 조회된다
+        assertThat(result)
+                .extracting(Memo::getTitle)
+                .containsExactly("new", "old");
+        assertThat(result).allMatch(m -> m.getLastViewedAt() == null);
+    }
+
+    @Test
+    @DisplayName("삭제된 메모는 최근 생성 조회에서 제외된다")
+    void findRecentCreated_deletedExcluded() {
+        // given
+        User user = userRepository.save(
+                User.createSocialUser("created-del@test.com", "유저", "profile.png", "google")
+        );
+
+        Memo alive = Memo.createMemo("살아있음", "content", user);
+        Memo deleted = Memo.createMemo("삭제됨", "content", user);
+        em.persist(alive);
+        em.persist(deleted);
+        deleted.delete();
+        em.flush();
+        em.clear();
+
+        // when
+        List<Memo> result = memoRepository.findRecentCreated(user.getId(), 6);
+
+        // then
+        assertThat(result)
+                .extracting(Memo::getTitle)
+                .containsExactly("살아있음");
+    }
+
+    @Test
+    @DisplayName("최근 생성 조회는 limit 개수만큼만 반환한다")
+    void findRecentCreated_respectsLimit() {
+        // given
+        User user = userRepository.save(
+                User.createSocialUser("created-limit@test.com", "유저", "profile.png", "google")
+        );
+
+        for (int i = 0; i < 5; i++) {
+            em.persist(Memo.createMemo("memo" + i, "content", user));
+        }
+        em.flush();
+        em.clear();
+
+        // when
+        List<Memo> result = memoRepository.findRecentCreated(user.getId(), 3);
+
+        // then
+        assertThat(result).hasSize(3);
+    }
+
+    private void forceCreatedAt(Long memoId, LocalDateTime createdAt) {
+        em.getEntityManager().createQuery("""
+                    update Memo m
+                    set m.createdAt = :createdAt
+                    where m.id = :id
+                """)
+                .setParameter("createdAt", createdAt)
+                .setParameter("id", memoId)
+                .executeUpdate();
+    }
 }

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -20,6 +20,7 @@ import org.project.domain.memo.dto.response.MemoDetailResponse;
 import org.project.domain.memo.dto.response.MemoListDashboardResponse;
 import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
 import org.project.domain.memo.dto.response.MemoRecentViewedResponse;
+import org.project.domain.memo.dto.response.RecentViewedSource;
 import org.project.domain.memo.dto.response.MemoRecommendationResponse;
 import org.project.domain.memo.dto.response.MemoResponse;
 import org.project.domain.memo.dto.response.MemoSearchResponse;
@@ -868,12 +869,14 @@ class MemoServiceImplTest {
     class RecentViewedMemos {
 
         @Test
-        @DisplayName("최근 열람한 메모를 리포지토리 정렬 순서대로 반환한다")
+        @DisplayName("최근 열람한 메모가 있으면 폴백 없이 열람 메모를 반환한다")
         void getRecentViewedMemos_returnsItems() {
             // given
             User user = User.builder().id(userId).build();
-            Memo m1 = Memo.builder().id(1L).title("최근1").content("내용").user(user).isDeleted(false).build();
-            Memo m2 = Memo.builder().id(2L).title("최근2").content("내용").user(user).isDeleted(false).build();
+            Memo m1 = Memo.builder().id(1L).title("최근1").content("내용").user(user)
+                    .isDeleted(false).lastViewedAt(LocalDateTime.now()).build();
+            Memo m2 = Memo.builder().id(2L).title("최근2").content("내용").user(user)
+                    .isDeleted(false).lastViewedAt(LocalDateTime.now().minusMinutes(1)).build();
 
             given(memoSearchProperties.getRecentViewedLimit()).willReturn(6);
             given(memoRepository.findRecentViewed(eq(userId), eq(6)))
@@ -883,21 +886,56 @@ class MemoServiceImplTest {
             MemoRecentViewedResponse response = memoService.getRecentViewedMemos(userId);
 
             // then
+            assertThat(response.source()).isEqualTo(RecentViewedSource.RECENT_VIEWED);
             assertThat(response.results()).extracting("memoId").containsExactly(1L, 2L);
+            assertThat(response.results()).allMatch(item -> item.lastViewedAt() != null);
+            // 열람 이력이 있으므로 최근 생성 폴백은 조회하지 않는다
+            verify(memoRepository, never()).findRecentCreated(anyLong(), anyInt());
         }
 
         @Test
-        @DisplayName("열람 이력이 없으면 빈 리스트를 반환한다")
-        void getRecentViewedMemos_empty() {
+        @DisplayName("열람 이력이 없으면 최근 생성 메모로 폴백한다 (lastViewedAt=null, createdAt 채움)")
+        void getRecentViewedMemos_fallbackToRecentCreated() {
             // given
+            User user = User.builder().id(userId).build();
+            LocalDateTime created = LocalDateTime.now().minusDays(1);
+            Memo created1 = Memo.builder().id(10L).title("생성1").content("내용").user(user)
+                    .isDeleted(false).build(); // lastViewedAt == null (한 번도 열람 안 함)
+            ReflectionTestUtils.setField(created1, "createdAt", created);
+
             given(memoSearchProperties.getRecentViewedLimit()).willReturn(6);
             given(memoRepository.findRecentViewed(eq(userId), eq(6)))
                     .willReturn(List.of());
+            given(memoRepository.findRecentCreated(eq(userId), eq(6)))
+                    .willReturn(List.of(created1));
 
             // when
             MemoRecentViewedResponse response = memoService.getRecentViewedMemos(userId);
 
             // then
+            assertThat(response.source()).isEqualTo(RecentViewedSource.RECENT_CREATED);
+            assertThat(response.results()).hasSize(1);
+            MemoRecentViewedResponse.Item item = response.results().get(0);
+            assertThat(item.memoId()).isEqualTo(10L);
+            assertThat(item.lastViewedAt()).isNull();
+            assertThat(item.createdAt()).isEqualTo(created);
+        }
+
+        @Test
+        @DisplayName("열람 이력도 생성 메모도 없으면 빈 리스트를 반환한다")
+        void getRecentViewedMemos_empty() {
+            // given
+            given(memoSearchProperties.getRecentViewedLimit()).willReturn(6);
+            given(memoRepository.findRecentViewed(eq(userId), eq(6)))
+                    .willReturn(List.of());
+            given(memoRepository.findRecentCreated(eq(userId), eq(6)))
+                    .willReturn(List.of());
+
+            // when
+            MemoRecentViewedResponse response = memoService.getRecentViewedMemos(userId);
+
+            // then — 열람 이력이 없어 생성 폴백을 시도했으므로 source는 RECENT_CREATED
+            assertThat(response.source()).isEqualTo(RecentViewedSource.RECENT_CREATED);
             assertThat(response.results()).isEmpty();
         }
     }


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #178 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 열람 이력이 있으면 → 최근 열람 메모 반환 (source: RECENT_VIEWED)
- 열람 이력이 0개면 → 최근 생성 메모(생성 최신순)로 폴백 (source: RECENT_CREATED)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 최근 열람 메모가 없을 경우, 최근 생성된 메모를 생성일 기준으로 조회해 자동으로 제공합니다.
  * 응답에 목록 출처가 추가되어 최근 열람(`RECENT_VIEWED`)과 최근 생성(`RECENT_CREATED`)을 구분할 수 있습니다.
  * 메모 항목에 생성일이 포함되며, 최근 생성 메모의 열람일은 비어 있을 수 있습니다.

* **문서**
  * API 설명에 폴백 동작과 응답 출처 구분 기준을 반영했습니다.

* **테스트**
  * 정렬, 삭제 메모 제외, 조회 개수 제한 및 폴백 동작을 검증하는 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->