### PR TITLE
[Chore] PATCH시 첨부 파일들 검증 보강 + request DTO 수정

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
@@ -40,11 +40,8 @@ public record MemoCreateRequest(
                 @NotBlank(message = "imageName은 비어 있을 수 없습니다.")
                 String imageName,
 
-                @Schema(description = "확장자 (필수)", example = "png")
-                @NotBlank(message = "extension은 비어 있을 수 없습니다.")
-                String extension,
-
-                @Schema(description = "정렬 우선순위", example = "0")
+                @Schema(description = "정렬 우선순위 (필수)", example = "0")
+                @NotNull(message = "priority는 null일 수 없습니다.")
                 Integer priority
         ) {
         }
@@ -60,11 +57,8 @@ public record MemoCreateRequest(
                 @NotBlank(message = "fileName은 비어 있을 수 없습니다.")
                 String fileName,
 
-                @Schema(description = "확장자 (필수)", example = "pdf")
-                @NotBlank(message = "extension은 비어 있을 수 없습니다.")
-                String extension,
-
-                @Schema(description = "정렬 우선순위", example = "0")
+                @Schema(description = "정렬 우선순위 (필수)", example = "0")
+                @NotNull(message = "priority는 null일 수 없습니다.")
                 Integer priority
         ) {
         }

--- a/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoCreateRequest.java
@@ -1,6 +1,8 @@
 package org.project.domain.memo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -18,9 +20,11 @@ public record MemoCreateRequest(
         @Schema(description = "태그 이름 목록", example = "[\"SOPT\", \"교양\", \"레퍼런스\"]")
         List<String> tagNames,
 
+        @Valid
         @Schema(description = "이미지 메타데이터 목록 (선택)")
         List<ImageRequest> images,
 
+        @Valid
         @Schema(description = "파일 메타데이터 목록 (선택)")
         List<FileRequest> files
 ) {
@@ -30,15 +34,14 @@ public record MemoCreateRequest(
                 String s3Key,
 
                 @Schema(
-                        description = "원본 이미지 파일명",
+                        description = "원본 이미지 파일명 (필수)",
                         example = "seminar_slide.png"
                 )
+                @NotBlank(message = "imageName은 비어 있을 수 없습니다.")
                 String imageName,
 
-                @Schema(description = "파일 크기(bytes)", example = "245678")
-                Long bytes,
-
-                @Schema(description = "확장자", example = "png")
+                @Schema(description = "확장자 (필수)", example = "png")
+                @NotBlank(message = "extension은 비어 있을 수 없습니다.")
                 String extension,
 
                 @Schema(description = "정렬 우선순위", example = "0")
@@ -51,15 +54,14 @@ public record MemoCreateRequest(
                 String s3Key,
 
                 @Schema(
-                        description = "원본 파일명",
+                        description = "원본 파일명 (필수)",
                         example = "SOPT_7th_seminar.pdf"
                 )
+                @NotBlank(message = "fileName은 비어 있을 수 없습니다.")
                 String fileName,
 
-                @Schema(description = "파일 크기(bytes)", example = "1048576")
-                Long bytes,
-
-                @Schema(description = "확장자", example = "pdf")
+                @Schema(description = "확장자 (필수)", example = "pdf")
+                @NotBlank(message = "extension은 비어 있을 수 없습니다.")
                 String extension,
 
                 @Schema(description = "정렬 우선순위", example = "0")

--- a/src/main/java/org/project/domain/memo/dto/request/MemoUpdateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoUpdateRequest.java
@@ -1,6 +1,7 @@
 package org.project.domain.memo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -20,10 +21,12 @@ public record MemoUpdateRequest(
         @NotNull(message = "tagNames는 null일 수 없습니다. 태그가 없으면 빈 배열([])로 보내주세요.")
         List<String> tagNames,
 
+        @Valid
         @Schema(description = "이미지 최종 상태 목록 (유지=imageId, 추가=s3Key, 없으면 [])")
         @NotNull(message = "images는 null일 수 없습니다. 이미지가 없으면 빈 배열([])로 보내주세요.")
         List<ImageEdit> images,
 
+        @Valid
         @Schema(description = "파일 최종 상태 목록 (유지=fileId, 추가=s3Key, 없으면 [])")
         @NotNull(message = "files는 null일 수 없습니다. 파일이 없으면 빈 배열([])로 보내주세요.")
         List<FileEdit> files
@@ -36,16 +39,14 @@ public record MemoUpdateRequest(
                 @Schema(description = "새로 추가하는 이미지의 S3 key. 기존 유지 시 null", example = "memo-image/1/uuid.png", nullable = true)
                 String s3Key,
 
-                @Schema(description = "원본 이미지 파일명 (추가 시)", example = "seminar_slide.png", nullable = true)
+                @Schema(description = "원본 이미지 파일명. 추가(s3Key) 시 필수, 유지 시 null", example = "seminar_slide.png", nullable = true)
                 String imageName,
 
-                @Schema(description = "파일 크기(bytes) (추가 시)", example = "245678", nullable = true)
-                Long bytes,
-
-                @Schema(description = "확장자 (추가 시)", example = "png", nullable = true)
+                @Schema(description = "확장자. 추가(s3Key) 시 필수, 유지 시 null", example = "png", nullable = true)
                 String extension,
 
-                @Schema(description = "정렬 우선순위", example = "0")
+                @Schema(description = "정렬 우선순위 (유지·추가 모두 필수)", example = "0")
+                @NotNull(message = "priority는 null일 수 없습니다.")
                 Integer priority
         ) {
         }
@@ -57,16 +58,14 @@ public record MemoUpdateRequest(
                 @Schema(description = "새로 추가하는 파일의 S3 key. 기존 유지 시 null", example = "memo-file/1/uuid.pdf", nullable = true)
                 String s3Key,
 
-                @Schema(description = "원본 파일명 (추가 시)", example = "SOPT_7th_seminar.pdf", nullable = true)
+                @Schema(description = "원본 파일명. 추가(s3Key) 시 필수, 유지 시 null", example = "SOPT_7th_seminar.pdf", nullable = true)
                 String fileName,
 
-                @Schema(description = "파일 크기(bytes) (추가 시)", example = "1048576", nullable = true)
-                Long bytes,
-
-                @Schema(description = "확장자 (추가 시)", example = "pdf", nullable = true)
+                @Schema(description = "확장자. 추가(s3Key) 시 필수, 유지 시 null", example = "pdf", nullable = true)
                 String extension,
 
-                @Schema(description = "정렬 우선순위", example = "0")
+                @Schema(description = "정렬 우선순위 (유지·추가 모두 필수)", example = "0")
+                @NotNull(message = "priority는 null일 수 없습니다.")
                 Integer priority
         ) {
         }

--- a/src/main/java/org/project/domain/memo/dto/request/MemoUpdateRequest.java
+++ b/src/main/java/org/project/domain/memo/dto/request/MemoUpdateRequest.java
@@ -42,9 +42,6 @@ public record MemoUpdateRequest(
                 @Schema(description = "원본 이미지 파일명. 추가(s3Key) 시 필수, 유지 시 null", example = "seminar_slide.png", nullable = true)
                 String imageName,
 
-                @Schema(description = "확장자. 추가(s3Key) 시 필수, 유지 시 null", example = "png", nullable = true)
-                String extension,
-
                 @Schema(description = "정렬 우선순위 (유지·추가 모두 필수)", example = "0")
                 @NotNull(message = "priority는 null일 수 없습니다.")
                 Integer priority
@@ -60,9 +57,6 @@ public record MemoUpdateRequest(
 
                 @Schema(description = "원본 파일명. 추가(s3Key) 시 필수, 유지 시 null", example = "SOPT_7th_seminar.pdf", nullable = true)
                 String fileName,
-
-                @Schema(description = "확장자. 추가(s3Key) 시 필수, 유지 시 null", example = "pdf", nullable = true)
-                String extension,
 
                 @Schema(description = "정렬 우선순위 (유지·추가 모두 필수)", example = "0")
                 @NotNull(message = "priority는 null일 수 없습니다.")

--- a/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoDetailResponse.java
@@ -54,13 +54,13 @@ public record MemoDetailResponse(
             @Schema(description = "이미지 URL (Presigned URL)")
             String imageUrl,
 
-            @Schema(description = "이미지 파일명. 저장된 파일명 정보가 없는 경우 null", example = "seminar_slide.png", nullable = true)
+            @Schema(description = "이미지 파일명", example = "seminar_slide.png")
             String imageName,
 
-            @Schema(description = "이미지 확장자. 저장된 확장자 정보가 없는 경우 null", example = "png", nullable = true)
+            @Schema(description = "이미지 확장자", example = "png")
             String imageExtension,
 
-            @Schema(description = "이미지 크기. 저장된 파일 크기 정보가 없는 경우 null", example = "0.24MB", nullable = true)
+            @Schema(description = "이미지 크기", example = "0.24MB")
             String imageSize
     ) {}
 
@@ -73,13 +73,13 @@ public record MemoDetailResponse(
             @Schema(description = "파일 다운로드 URL (Presigned URL)")
             String fileUrl,
 
-            @Schema(description = "파일명. 저장된 파일명 정보가 없는 경우 null", example = "SOPT_7th_seminar.pdf", nullable = true)
+            @Schema(description = "파일명", example = "SOPT_7th_seminar.pdf")
             String fileName,
 
-            @Schema(description = "파일 확장자. 저장된 확장자 정보가 없는 경우 null", example = "pdf", nullable = true)
+            @Schema(description = "파일 확장자", example = "pdf")
             String fileExtension,
 
-            @Schema(description = "파일 크기. 저장된 파일 크기 정보가 없는 경우 null", example = "1.00GB", nullable = true)
+            @Schema(description = "파일 크기", example = "1.00GB")
             String fileSize
     ) {}
 

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -86,6 +86,20 @@ public class MemoServiceImpl implements MemoService {
     private static final long MAX_IMAGE_BYTES = 5L * 1024 * 1024;
     private static final long MAX_FILE_BYTES = 10L * 1024 * 1024;
 
+    // 확장자는 발급 시점에 받은 값이 그대로 s3Key에 박히고, 저장 시 그 키에서 다시 읽어 쓴다.
+    // 따라서 허용 목록을 여기서 막아야 이후 단계 전체가 신뢰 가능해진다.
+    // 이미지 목록은 OCR이 mimeType을 판별할 수 있는 형식과 일치시킨다(MemoImageBinaryLoader).
+    private static final Set<String> ALLOWED_IMAGE_EXTENSIONS =
+            Set.of("png", "jpg", "jpeg", "webp", "gif");
+    // 파일은 Tika가 본문을 뽑아 임베딩한다. 목록에 없는 확장자는 업로드 자체가 막히므로,
+    // 파싱이 안 되더라도(예: hwp) 사용자가 첨부할 법한 문서 형식은 허용해 둔다.
+    private static final Set<String> ALLOWED_FILE_EXTENSIONS = Set.of(
+            "pdf", "txt", "md", "csv", "rtf",
+            "doc", "docx", "ppt", "pptx", "xls", "xlsx",
+            "hwp", "hwpx",
+            "odt", "ods", "odp"
+    );
+
     public MemoPresignedUrlResponse issuePresignedUrls(
             Long userId,
             MemoPresignedUrlRequest request
@@ -94,6 +108,8 @@ public class MemoServiceImpl implements MemoService {
         validateFileCount(request.files());
         validateBytes(request.images(), MemoPresignedUrlRequest.UploadRequest::bytes, MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE);
         validateBytes(request.files(), MemoPresignedUrlRequest.UploadRequest::bytes, MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE);
+        validateExtensions(request.images(), ALLOWED_IMAGE_EXTENSIONS);
+        validateExtensions(request.files(), ALLOWED_FILE_EXTENSIONS);
 
         List<MemoPresignedUrlResponse.PresignedUrlResponse> imageUrls =
                 request.images().stream()
@@ -222,8 +238,8 @@ public class MemoServiceImpl implements MemoService {
             if ((e.imageId() == null) == (e.s3Key() == null)) {
                 throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
             }
-            // 신규 추가분은 파일명·확장자가 필수. 유지분은 서버가 이미 보관하므로 요구하지 않는다.
-            if (e.s3Key() != null && (isBlank(e.imageName()) || isBlank(e.extension()))) {
+            // 신규 추가분은 파일명이 필수(확장자는 s3Key에서 뽑는다). 유지분은 서버가 이미 보관하므로 요구하지 않는다.
+            if (e.s3Key() != null && isBlank(e.imageName())) {
                 throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
             }
         }
@@ -293,7 +309,7 @@ public class MemoServiceImpl implements MemoService {
                 .imageS3Key(edit.s3Key())
                 .imageName(edit.imageName())
                 .imageBytes(actualBytes)
-                .imageExtension(edit.extension())
+                .imageExtension(s3KeyUtil.extractExtension(edit.s3Key()))
                 .imagePriority(edit.priority())
                 .build();
     }
@@ -306,8 +322,8 @@ public class MemoServiceImpl implements MemoService {
             if ((e.fileId() == null) == (e.s3Key() == null)) {
                 throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
             }
-            // 신규 추가분은 파일명·확장자가 필수. 유지분은 서버가 이미 보관하므로 요구하지 않는다.
-            if (e.s3Key() != null && (isBlank(e.fileName()) || isBlank(e.extension()))) {
+            // 신규 추가분은 파일명이 필수(확장자는 s3Key에서 뽑는다). 유지분은 서버가 이미 보관하므로 요구하지 않는다.
+            if (e.s3Key() != null && isBlank(e.fileName())) {
                 throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
             }
         }
@@ -372,7 +388,7 @@ public class MemoServiceImpl implements MemoService {
                 .fileS3Key(edit.s3Key())
                 .fileName(edit.fileName())
                 .fileBytes(actualBytes)
-                .fileExtension(edit.extension())
+                .fileExtension(s3KeyUtil.extractExtension(edit.s3Key()))
                 .filePriority(edit.priority())
                 .build();
     }
@@ -852,7 +868,7 @@ public class MemoServiceImpl implements MemoService {
                 .imageS3Key(request.s3Key())
                 .imageName(request.imageName())
                 .imageBytes(actualBytes)
-                .imageExtension(request.extension())
+                .imageExtension(s3KeyUtil.extractExtension(request.s3Key()))
                 .imagePriority(request.priority())
                 .build();
     }
@@ -895,7 +911,7 @@ public class MemoServiceImpl implements MemoService {
                 .fileS3Key(request.s3Key())
                 .fileName(request.fileName())
                 .fileBytes(actualBytes)
-                .fileExtension(request.extension())
+                .fileExtension(s3KeyUtil.extractExtension(request.s3Key()))
                 .filePriority(request.priority())
                 .build();
     }
@@ -1024,6 +1040,25 @@ public class MemoServiceImpl implements MemoService {
     }
 
     private record UploadedMedia(String s3Key, long bytes) {
+    }
+
+    // presigned URL 발급 시점의 확장자 검증. 여기서 통과한 값만 s3Key에 들어간다.
+    private void validateExtensions(
+            List<MemoPresignedUrlRequest.UploadRequest> items,
+            Set<String> allowed
+    ) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        boolean anyUnsupported = items.stream()
+                .map(MemoPresignedUrlRequest.UploadRequest::extension)
+                .anyMatch(extension -> extension == null
+                        || !allowed.contains(extension.toLowerCase(Locale.ROOT)));
+
+        if (anyUnsupported) {
+            throw new MemoException(MemoErrorCode.UNSUPPORTED_EXTENSION);
+        }
     }
 
     private <T> void validateBytes(

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -222,6 +222,10 @@ public class MemoServiceImpl implements MemoService {
             if ((e.imageId() == null) == (e.s3Key() == null)) {
                 throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
             }
+            // 신규 추가분은 파일명·확장자가 필수. 유지분은 서버가 이미 보관하므로 요구하지 않는다.
+            if (e.s3Key() != null && (isBlank(e.imageName()) || isBlank(e.extension()))) {
+                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+            }
         }
 
         Map<Long, MemoImage> existingById = memo.getMemoImages().stream()
@@ -245,7 +249,12 @@ public class MemoServiceImpl implements MemoService {
         if (keepEdits.size() + addEdits.size() > MAX_IMAGE_COUNT) {
             throw new MemoException(MemoErrorCode.TOO_MANY_IMAGES);
         }
-        validateBytes(addEdits, MemoUpdateRequest.ImageEdit::bytes, MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE);
+        // 신규 추가분만 S3 실제 객체 기준으로 검증 (유지분은 저장 시점에 검증 완료)
+        Map<String, Long> actualBytesByKey = validateUploadedMedia(
+                userId,
+                extractS3Keys(addEdits, MemoUpdateRequest.ImageEdit::s3Key),
+                List.of()
+        );
 
         // 유지 이미지 우선순위 갱신
         keepEdits.forEach(e -> existingById.get(e.imageId()).updatePriority(e.priority()));
@@ -266,7 +275,7 @@ public class MemoServiceImpl implements MemoService {
         // 추가 저장 + 임베딩 이벤트 (신규 첨부만 재임베딩)
         if (!addEdits.isEmpty()) {
             List<MemoImage> added = addEdits.stream()
-                    .map(e -> createMemoImageFromEdit(memo, e, userId))
+                    .map(e -> createMemoImageFromEdit(memo, e, actualBytesByKey.get(e.s3Key())))
                     .toList();
             memoImageRepository.saveAll(added);
             eventPublisher.publishEvent(new MemoImageCreatedEvent(
@@ -278,14 +287,12 @@ public class MemoServiceImpl implements MemoService {
         return new RemovedMedia(removedIds, removedKeys);
     }
 
-    private MemoImage createMemoImageFromEdit(Memo memo, MemoUpdateRequest.ImageEdit edit, Long userId) {
-        s3KeyUtil.validateS3KeyOwner(userId, edit.s3Key());
-
+    private MemoImage createMemoImageFromEdit(Memo memo, MemoUpdateRequest.ImageEdit edit, Long actualBytes) {
         return MemoImage.builder()
                 .memo(memo)
                 .imageS3Key(edit.s3Key())
                 .imageName(edit.imageName())
-                .imageBytes(edit.bytes())
+                .imageBytes(actualBytes)
                 .imageExtension(edit.extension())
                 .imagePriority(edit.priority())
                 .build();
@@ -298,6 +305,10 @@ public class MemoServiceImpl implements MemoService {
         for (MemoUpdateRequest.FileEdit e : edits) {
             if ((e.fileId() == null) == (e.s3Key() == null)) {
                 throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
+            }
+            // 신규 추가분은 파일명·확장자가 필수. 유지분은 서버가 이미 보관하므로 요구하지 않는다.
+            if (e.s3Key() != null && (isBlank(e.fileName()) || isBlank(e.extension()))) {
+                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
             }
         }
 
@@ -320,7 +331,12 @@ public class MemoServiceImpl implements MemoService {
         if (keepEdits.size() + addEdits.size() > MAX_FILE_COUNT) {
             throw new MemoException(MemoErrorCode.TOO_MANY_FILES);
         }
-        validateBytes(addEdits, MemoUpdateRequest.FileEdit::bytes, MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE);
+        // 신규 추가분만 S3 실제 객체 기준으로 검증 (유지분은 저장 시점에 검증 완료)
+        Map<String, Long> actualBytesByKey = validateUploadedMedia(
+                userId,
+                List.of(),
+                extractS3Keys(addEdits, MemoUpdateRequest.FileEdit::s3Key)
+        );
 
         keepEdits.forEach(e -> existingById.get(e.fileId()).updatePriority(e.priority()));
 
@@ -338,7 +354,7 @@ public class MemoServiceImpl implements MemoService {
 
         if (!addEdits.isEmpty()) {
             List<MemoFile> added = addEdits.stream()
-                    .map(e -> createMemoFileFromEdit(memo, e, userId))
+                    .map(e -> createMemoFileFromEdit(memo, e, actualBytesByKey.get(e.s3Key())))
                     .toList();
             memoFileRepository.saveAll(added);
             eventPublisher.publishEvent(new MemoFileCreatedEvent(
@@ -350,14 +366,12 @@ public class MemoServiceImpl implements MemoService {
         return new RemovedMedia(removedIds, removedKeys);
     }
 
-    private MemoFile createMemoFileFromEdit(Memo memo, MemoUpdateRequest.FileEdit edit, Long userId) {
-        s3KeyUtil.validateS3KeyOwner(userId, edit.s3Key());
-
+    private MemoFile createMemoFileFromEdit(Memo memo, MemoUpdateRequest.FileEdit edit, Long actualBytes) {
         return MemoFile.builder()
                 .memo(memo)
                 .fileS3Key(edit.s3Key())
                 .fileName(edit.fileName())
-                .fileBytes(edit.bytes())
+                .fileBytes(actualBytes)
                 .fileExtension(edit.extension())
                 .filePriority(edit.priority())
                 .build();
@@ -944,20 +958,43 @@ public class MemoServiceImpl implements MemoService {
     }
 
     private Map<String, Long> validateUploadedMedia(Long userId, MemoCreateRequest request) {
+        return validateUploadedMedia(
+                userId,
+                extractS3Keys(request.images(), MemoCreateRequest.ImageRequest::s3Key),
+                extractS3Keys(request.files(), MemoCreateRequest.FileRequest::s3Key)
+        );
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private <T> List<String> extractS3Keys(List<T> items, Function<T, String> keyExtractor) {
+        if (items == null) {
+            return List.of();
+        }
+        return items.stream().map(keyExtractor).toList();
+    }
+
+    /**
+     * 신규 업로드된 첨부의 s3Key(소유자·용도별 prefix)와 S3 실제 객체 크기를 검증한다.
+     * 메모 생성/수정 양쪽에서 공용으로 쓰며, 반환값은 s3Key → 실제 바이트 수.
+     */
+    private Map<String, Long> validateUploadedMedia(
+            Long userId,
+            List<String> imageS3Keys,
+            List<String> fileS3Keys
+    ) {
         List<CompletableFuture<UploadedMedia>> validations = new ArrayList<>();
 
-        if (request.images() != null) {
-            request.images().forEach(image -> validations.add(CompletableFuture.supplyAsync(
-                    () -> validateUploadedMedia(userId, "memo-image", image.s3Key(), MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE),
-                    ioExecutor
-            )));
-        }
-        if (request.files() != null) {
-            request.files().forEach(file -> validations.add(CompletableFuture.supplyAsync(
-                    () -> validateUploadedMedia(userId, "memo-file", file.s3Key(), MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE),
-                    ioExecutor
-            )));
-        }
+        imageS3Keys.forEach(s3Key -> validations.add(CompletableFuture.supplyAsync(
+                () -> validateUploadedMedia(userId, "memo-image", s3Key, MAX_IMAGE_BYTES, MemoErrorCode.IMAGE_TOO_LARGE),
+                ioExecutor
+        )));
+        fileS3Keys.forEach(s3Key -> validations.add(CompletableFuture.supplyAsync(
+                () -> validateUploadedMedia(userId, "memo-file", s3Key, MAX_FILE_BYTES, MemoErrorCode.FILE_TOO_LARGE),
+                ioExecutor
+        )));
 
         try {
             return validations.stream()

--- a/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
@@ -17,7 +17,8 @@ public enum MemoErrorCode implements ErrorCode {
     MEMO_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 메모 이미지를 찾을 수 없습니다."),
     MEMO_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 메모 파일을 찾을 수 없습니다."),
     INVALID_ATTACHMENT_EDIT(HttpStatus.BAD_REQUEST, 400, "각 첨부 항목은 유지(imageId/fileId) 또는 추가(s3Key) 중 하나를 포함해야 합니다. 이미지·파일이 없으면 빈 배열([])로 보내주세요."),
-    MISSING_ATTACHMENT_METADATA(HttpStatus.BAD_REQUEST, 400, "새로 추가하는 첨부는 파일명(imageName/fileName)과 확장자(extension)를 함께 보내주세요."),
+    MISSING_ATTACHMENT_METADATA(HttpStatus.BAD_REQUEST, 400, "새로 추가하는 첨부는 파일명(imageName/fileName)을 함께 보내주세요."),
+    UNSUPPORTED_EXTENSION(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 확장자입니다."),
     EMPTY_SEARCH_QUERY(HttpStatus.BAD_REQUEST, 400, "검색어를 입력해주세요."),
     EMPTY_MEMO_IDS(HttpStatus.BAD_REQUEST, 400, "선택된 메모가 없습니다.");
 

--- a/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/MemoErrorCode.java
@@ -17,6 +17,7 @@ public enum MemoErrorCode implements ErrorCode {
     MEMO_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 메모 이미지를 찾을 수 없습니다."),
     MEMO_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 메모 파일을 찾을 수 없습니다."),
     INVALID_ATTACHMENT_EDIT(HttpStatus.BAD_REQUEST, 400, "각 첨부 항목은 유지(imageId/fileId) 또는 추가(s3Key) 중 하나를 포함해야 합니다. 이미지·파일이 없으면 빈 배열([])로 보내주세요."),
+    MISSING_ATTACHMENT_METADATA(HttpStatus.BAD_REQUEST, 400, "새로 추가하는 첨부는 파일명(imageName/fileName)과 확장자(extension)를 함께 보내주세요."),
     EMPTY_SEARCH_QUERY(HttpStatus.BAD_REQUEST, 400, "검색어를 입력해주세요."),
     EMPTY_MEMO_IDS(HttpStatus.BAD_REQUEST, 400, "선택된 메모가 없습니다.");
 

--- a/src/main/java/org/project/global/util/S3KeyUtil.java
+++ b/src/main/java/org/project/global/util/S3KeyUtil.java
@@ -4,6 +4,8 @@ import org.project.global.exception.domainException.MemoException;
 import org.project.global.exception.errorcode.MemoErrorCode;
 import org.springframework.stereotype.Component;
 
+import java.util.Locale;
+
 @Component
 public class S3KeyUtil {
 
@@ -34,6 +36,26 @@ public class S3KeyUtil {
         if (!ownerId.equals(requestUserId)) {
             throw new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH);
         }
+    }
+
+    /**
+     * s3Key에서 확장자를 추출한다. 키는 서버가 발급할 때 `{prefix}/{userId}/{uuid}.{ext}` 형태로 만들므로,
+     * 확장자는 클라이언트가 다시 보내지 않고 여기서 뽑아 쓴다(요청값과 실제 객체가 어긋나는 것을 원천 차단).
+     */
+    public String extractExtension(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) {
+            throw new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        String fileName = s3Key.substring(s3Key.lastIndexOf('/') + 1);
+        int dotIndex = fileName.lastIndexOf('.');
+
+        // 확장자가 없거나(`uuid`) 점으로 끝나면(`uuid.`) 잘못된 키
+        if (dotIndex == -1 || dotIndex == fileName.length() - 1) {
+            throw new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        return fileName.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
     }
 
     public void validateS3Key(Long requestUserId, String prefix, String s3Key) {

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -433,14 +433,12 @@ class MemoControllerTest {
             MemoCreateRequest.ImageRequest image1 = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/53238404-f89d-4728-9dc0-efb2a3c7787b.png",
                     "seminar_slide.png",
-                    "png",
                     1
             );
 
             MemoCreateRequest.ImageRequest image2 = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/another-uuid.jpg",
                     "photo.jpg",
-                    "jpg",
                     2
             );
 
@@ -487,7 +485,6 @@ class MemoControllerTest {
             MemoCreateRequest.FileRequest file = new MemoCreateRequest.FileRequest(
                     "memo-file/1/780fd26c-8ab7-4762-b148-b9c8c071795b.pdf",
                     "SOPT_7th_seminar.pdf",
-                    "pdf",
                     1
             );
 
@@ -534,14 +531,12 @@ class MemoControllerTest {
             MemoCreateRequest.ImageRequest image = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/uuid-image.png",
                     "slide.png",
-                    "png",
                     1
             );
 
             MemoCreateRequest.FileRequest file = new MemoCreateRequest.FileRequest(
                     "memo-file/1/uuid-file.pdf",
                     "document.pdf",
-                    "pdf",
                     1
             );
 
@@ -738,10 +733,10 @@ class MemoControllerTest {
         }
 
         @Test
-        @DisplayName("이미지 항목의 extension이 공백이면 400을 반환한다")
+        @DisplayName("이미지 항목의 priority가 null이면 400을 반환한다")
         @WithMockCustomUser(userId = 1L)
-        void createMemo_ImageExtensionBlank_BadRequest() throws Exception {
-            // given: 빈 문자열·공백도 거부한다 (@NotBlank)
+        void createMemo_ImagePriorityNull_BadRequest() throws Exception {
+            // given: priority는 DB 컬럼이 nullable = false라 요청 단계에서 막는다
             String requestJson = """
                     {
                         "title": "제목",
@@ -751,8 +746,7 @@ class MemoControllerTest {
                             {
                                 "s3Key": "memo-image/1/uuid.png",
                                 "imageName": "seminar_slide.png",
-                                "extension": "  ",
-                                "priority": 0
+                                "priority": null
                             }
                         ],
                         "files": []

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -433,7 +433,6 @@ class MemoControllerTest {
             MemoCreateRequest.ImageRequest image1 = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/53238404-f89d-4728-9dc0-efb2a3c7787b.png",
                     "seminar_slide.png",
-                    245678L,
                     "png",
                     1
             );
@@ -441,7 +440,6 @@ class MemoControllerTest {
             MemoCreateRequest.ImageRequest image2 = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/another-uuid.jpg",
                     "photo.jpg",
-                    532198L,
                     "jpg",
                     2
             );
@@ -489,7 +487,6 @@ class MemoControllerTest {
             MemoCreateRequest.FileRequest file = new MemoCreateRequest.FileRequest(
                     "memo-file/1/780fd26c-8ab7-4762-b148-b9c8c071795b.pdf",
                     "SOPT_7th_seminar.pdf",
-                    1048576L,
                     "pdf",
                     1
             );
@@ -537,7 +534,6 @@ class MemoControllerTest {
             MemoCreateRequest.ImageRequest image = new MemoCreateRequest.ImageRequest(
                     "memo-image/1/uuid-image.png",
                     "slide.png",
-                    245678L,
                     "png",
                     1
             );
@@ -545,7 +541,6 @@ class MemoControllerTest {
             MemoCreateRequest.FileRequest file = new MemoCreateRequest.FileRequest(
                     "memo-file/1/uuid-file.pdf",
                     "document.pdf",
-                    1048576L,
                     "pdf",
                     1
             );
@@ -1216,6 +1211,66 @@ class MemoControllerTest {
                         "tagNames": null,
                         "images": null,
                         "files": null
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/memo/{memoId}", 100L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(memoService, never()).updateMemo(anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("이미지 항목의 priority가 null이면 400을 반환한다")
+        @WithMockCustomUser(userId = 1L)
+        void updateMemo_ImagePriorityNull_BadRequest() throws Exception {
+            // given: priority는 유지/추가 무관하게 필수 (DB 컬럼이 nullable = false)
+            String requestJson = """
+                    {
+                        "title": "새 제목",
+                        "content": "새 내용",
+                        "tagNames": [],
+                        "images": [
+                            {
+                                "imageId": 10,
+                                "priority": null
+                            }
+                        ],
+                        "files": []
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/memo/{memoId}", 100L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(memoService, never()).updateMemo(anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("파일 항목의 priority가 null이면 400을 반환한다")
+        @WithMockCustomUser(userId = 1L)
+        void updateMemo_FilePriorityNull_BadRequest() throws Exception {
+            // given
+            String requestJson = """
+                    {
+                        "title": "새 제목",
+                        "content": "새 내용",
+                        "tagNames": [],
+                        "images": [],
+                        "files": [
+                            {
+                                "fileId": 20,
+                                "priority": null
+                            }
+                        ]
                     }
                     """;
 

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -706,6 +706,101 @@ class MemoControllerTest {
             verify(memoService, never()).createMemo(anyLong(), any());
         }
 
+        @Test
+        @DisplayName("이미지 항목의 imageName이 누락되면 400을 반환한다")
+        @WithMockCustomUser(userId = 1L)
+        void createMemo_ImageNameMissing_BadRequest() throws Exception {
+            // given: 첨부를 보낼 경우 파일명·확장자는 필수
+            String requestJson = """
+                    {
+                        "title": "제목",
+                        "content": "내용",
+                        "tagNames": [],
+                        "images": [
+                            {
+                                "s3Key": "memo-image/1/uuid.png",
+                                "extension": "png",
+                                "priority": 0
+                            }
+                        ],
+                        "files": []
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/v1/memo")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(memoService, never()).createMemo(anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("이미지 항목의 extension이 공백이면 400을 반환한다")
+        @WithMockCustomUser(userId = 1L)
+        void createMemo_ImageExtensionBlank_BadRequest() throws Exception {
+            // given: 빈 문자열·공백도 거부한다 (@NotBlank)
+            String requestJson = """
+                    {
+                        "title": "제목",
+                        "content": "내용",
+                        "tagNames": [],
+                        "images": [
+                            {
+                                "s3Key": "memo-image/1/uuid.png",
+                                "imageName": "seminar_slide.png",
+                                "extension": "  ",
+                                "priority": 0
+                            }
+                        ],
+                        "files": []
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/v1/memo")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(memoService, never()).createMemo(anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("파일 항목의 fileName이 null이면 400을 반환한다")
+        @WithMockCustomUser(userId = 1L)
+        void createMemo_FileNameNull_BadRequest() throws Exception {
+            // given
+            String requestJson = """
+                    {
+                        "title": "제목",
+                        "content": "내용",
+                        "tagNames": [],
+                        "images": [],
+                        "files": [
+                            {
+                                "s3Key": "memo-file/1/uuid.pdf",
+                                "fileName": null,
+                                "extension": "pdf",
+                                "priority": 0
+                            }
+                        ]
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/v1/memo")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(memoService, never()).createMemo(anyLong(), any());
+        }
+
     }
 
     @Nested

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -122,7 +122,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.ImageRequest(
                             "memo-image/1/test.png",
                             "test.png",
-                            1024L,
                             "png",
                             1
                     );
@@ -131,7 +130,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.FileRequest(
                             "memo-file/1/test.pdf",
                             "test.pdf",
-                            2048L,
                             "pdf",
                             1
                     );
@@ -172,12 +170,12 @@ class MemoServiceImplTest {
             given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             List<MemoCreateRequest.ImageRequest> images = List.of(
-                    new MemoCreateRequest.ImageRequest("memo-image/1/1.png", "1.png", 100L, "png", 1),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/2.png", "2.png", 100L, "png", 2),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/3.png", "3.png", 100L, "png", 3),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/4.png", "4.png", 100L, "png", 4),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/5.png", "5.png", 100L, "png", 5),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/6.png", "6.png", 100L, "png", 6)
+                    new MemoCreateRequest.ImageRequest("memo-image/1/1.png", "1.png", "png", 1),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/2.png", "2.png", "png", 2),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/3.png", "3.png", "png", 3),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/4.png", "4.png", "png", 4),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/5.png", "5.png", "png", 5),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/6.png", "6.png", "png", 6)
             );
 
             MemoCreateRequest tooManyImagesRequest = new MemoCreateRequest(
@@ -199,7 +197,7 @@ class MemoServiceImplTest {
             given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             List<MemoCreateRequest.FileRequest> files = List.of(
-                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", 1L, "pdf", 1)
+                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", "pdf", 1)
             );
             given(s3Util.getObjectMetadata("memo-file/1/1.pdf"))
                     .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
@@ -293,7 +291,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.ImageRequest(
                             "memo-image/999/invalid.png",
                             "invalid.png",
-                            1024L,
                             "png",
                             1
                     );
@@ -329,7 +326,7 @@ class MemoServiceImplTest {
         }
 
         @Test
-        @DisplayName("요청 bytes가 아닌 S3 실제 크기를 저장한다")
+        @DisplayName("S3 실제 객체 크기를 조회해 저장한다")
         void createMemo_savesActualS3ObjectSize() {
             when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
             when(memoRepository.save(any(Memo.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -1122,6 +1119,9 @@ class MemoServiceImplTest {
         @BeforeEach
         void setUp() {
             user = User.builder().id(userId).build();
+            ReflectionTestUtils.setField(memoService, "ioExecutor", (Executor) Runnable::run);
+            lenient().when(s3Util.getObjectMetadata(anyString()))
+                    .thenReturn(new S3Util.S3ObjectMetadata(1_024L, "application/octet-stream"));
         }
 
         private Memo ownedMemo(String title, String content) {
@@ -1279,7 +1279,7 @@ class MemoServiceImplTest {
                     });
 
             MemoUpdateRequest.ImageEdit newImage =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", 1024L, "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of());
 
@@ -1287,7 +1287,7 @@ class MemoServiceImplTest {
             memoService.updateMemo(userId, memoId, req);
 
             // then
-            verify(s3KeyUtil).validateS3KeyOwner(userId, "memo-image/1/new.png");
+            verify(s3KeyUtil).validateS3Key(userId, "memo-image", "memo-image/1/new.png");
             verify(memoImageRepository).saveAll(anyList());
             verify(eventPublisher).publishEvent(any(MemoImageCreatedEvent.class));
         }
@@ -1306,7 +1306,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit keepEdit =
-                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(keepEdit), List.of());
 
@@ -1335,7 +1335,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit keepEdit =
-                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, null, 3);
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 3);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(keepEdit), List.of());
 
@@ -1358,10 +1358,10 @@ class MemoServiceImplTest {
                 MemoImage img = MemoImage.builder()
                         .id(i).memo(memo).imageS3Key("memo-image/1/" + i + ".png").imagePriority((int) i).build();
                 memo.getMemoImages().add(img);
-                edits.add(new MemoUpdateRequest.ImageEdit(i, null, null, null, null, (int) i));
+                edits.add(new MemoUpdateRequest.ImageEdit(i, null, null, null, (int) i));
             }
             for (int i = 0; i < 3; i++) {
-                edits.add(new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new" + i + ".png", "n.png", 1L, "png", i));
+                edits.add(new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new" + i + ".png", "n.png", "png", i));
             }
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
@@ -1381,7 +1381,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit bad =
-                    new MemoUpdateRequest.ImageEdit(null, null, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(null, null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(bad), List.of());
 
@@ -1402,7 +1402,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit ambiguous =
-                    new MemoUpdateRequest.ImageEdit(10L, "memo-image/1/new.png", "new.png", 1L, "png", 0);
+                    new MemoUpdateRequest.ImageEdit(10L, "memo-image/1/new.png", "new.png", "png", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(ambiguous), List.of());
 
@@ -1420,7 +1420,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.FileEdit bad =
-                    new MemoUpdateRequest.FileEdit(null, null, null, null, null, 0);
+                    new MemoUpdateRequest.FileEdit(null, null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(bad));
 
@@ -1438,7 +1438,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit ghost =
-                    new MemoUpdateRequest.ImageEdit(999L, null, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(999L, null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(ghost), List.of());
 
@@ -1446,6 +1446,236 @@ class MemoServiceImplTest {
             assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
                     .isInstanceOf(MemoException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.MEMO_IMAGE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("새 첨부는 S3 실제 객체 크기를 조회해 저장한다")
+        void updateMemo_addsAttachment_savesActualS3ObjectSize() {
+            // given: 요청은 1KB라고 주장하지만 S3 실제 크기는 다름
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+            given(s3Util.getObjectMetadata("memo-image/1/new.png"))
+                    .willReturn(new S3Util.S3ObjectMetadata(3_000L, "image/png"));
+            given(s3Util.getObjectMetadata("memo-file/1/new.pdf"))
+                    .willReturn(new S3Util.S3ObjectMetadata(4_000L, "application/pdf"));
+
+            MemoUpdateRequest.ImageEdit newImage =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
+            MemoUpdateRequest.FileEdit newFile =
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of(newFile));
+
+            // when
+            memoService.updateMemo(userId, memoId, req);
+
+            // then
+            ArgumentCaptor<List<MemoImage>> imageCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<List<MemoFile>> fileCaptor = ArgumentCaptor.forClass(List.class);
+            verify(memoImageRepository).saveAll(imageCaptor.capture());
+            verify(memoFileRepository).saveAll(fileCaptor.capture());
+
+            assertThat(imageCaptor.getValue().get(0).getImageBytes()).isEqualTo(3_000L);
+            assertThat(fileCaptor.getValue().get(0).getFileBytes()).isEqualTo(4_000L);
+        }
+
+        @Test
+        @DisplayName("새 이미지의 S3 실제 크기가 5MB를 초과하면 IMAGE_TOO_LARGE 예외가 발생한다")
+        void updateMemo_addedImageActuallyTooLarge_throws() {
+            // given: 실제 객체가 5MB 초과
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+            given(s3Util.getObjectMetadata("memo-image/1/huge.png"))
+                    .willReturn(new S3Util.S3ObjectMetadata(5L * 1024 * 1024 + 1, "image/png"));
+
+            MemoUpdateRequest.ImageEdit huge =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/huge.png", "huge.png", "png", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(huge), List.of());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.IMAGE_TOO_LARGE);
+
+            verify(memoImageRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("새 파일의 S3 실제 크기가 10MB를 초과하면 FILE_TOO_LARGE 예외가 발생한다")
+        void updateMemo_addedFileActuallyTooLarge_throws() {
+            // given
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+            given(s3Util.getObjectMetadata("memo-file/1/huge.pdf"))
+                    .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
+
+            MemoUpdateRequest.FileEdit huge =
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/huge.pdf", "huge.pdf", "pdf", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(huge));
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.FILE_TOO_LARGE);
+
+            verify(memoFileRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("새 첨부의 s3Key를 용도별 prefix까지 검증한다")
+        void updateMemo_validatesS3KeyPrefixByMediaType() {
+            // given
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest.ImageEdit newImage =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
+            MemoUpdateRequest.FileEdit newFile =
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of(newFile));
+
+            // when
+            memoService.updateMemo(userId, memoId, req);
+
+            // then
+            verify(s3KeyUtil).validateS3Key(userId, "memo-image", "memo-image/1/new.png");
+            verify(s3KeyUtil).validateS3Key(userId, "memo-file", "memo-file/1/new.pdf");
+        }
+
+        @Test
+        @DisplayName("prefix 검증에 실패하면 첨부를 저장하지 않는다")
+        void updateMemo_invalidS3KeyPrefix_doesNotSave() {
+            // given: 이미지 자리에 파일 key를 넣은 요청
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+            doThrow(new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT))
+                    .when(s3KeyUtil)
+                    .validateS3Key(eq(userId), eq("memo-image"), anyString());
+
+            MemoUpdateRequest.ImageEdit crossed =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(crossed), List.of());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+
+            verify(memoImageRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("새 이미지에 imageName이 없으면 MISSING_ATTACHMENT_METADATA 예외가 발생한다")
+        void updateMemo_addImageWithoutName_throws() {
+            // given
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest.ImageEdit noName =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", null, "png", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(noName), List.of());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+
+            verify(memoImageRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("새 이미지에 extension이 비어 있으면 MISSING_ATTACHMENT_METADATA 예외가 발생한다")
+        void updateMemo_addImageWithBlankExtension_throws() {
+            // given
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest.ImageEdit blankExt =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "  ", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(blankExt), List.of());
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+        }
+
+        @Test
+        @DisplayName("새 파일에 fileName이 없으면 MISSING_ATTACHMENT_METADATA 예외가 발생한다")
+        void updateMemo_addFileWithoutName_throws() {
+            // given
+            Memo memo = ownedMemo("제목", "내용");
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest.FileEdit noName =
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", null, "pdf", 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(noName));
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+
+            verify(memoFileRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("유지 항목은 name·extension이 없어도 정상 처리한다")
+        void updateMemo_keepWithoutMetadata_succeeds() {
+            // given: 자동저장은 유지 항목에 id와 priority만 실어 보낸다
+            Memo memo = ownedMemo("제목", "내용");
+            MemoImage keepImage = MemoImage.builder()
+                    .id(10L).memo(memo).imageS3Key("memo-image/1/keep.png").imagePriority(0).build();
+            MemoFile keepFile = MemoFile.builder()
+                    .id(20L).memo(memo).fileS3Key("memo-file/1/keep.pdf").filePriority(0).build();
+            memo.getMemoImages().add(keepImage);
+            memo.getMemoFiles().add(keepFile);
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest req = new MemoUpdateRequest(
+                    "제목", "내용", List.of(),
+                    List.of(new MemoUpdateRequest.ImageEdit(10L, null, null, null, 1)),
+                    List.of(new MemoUpdateRequest.FileEdit(20L, null, null, null, 2))
+            );
+
+            // when
+            memoService.updateMemo(userId, memoId, req);
+
+            // then
+            assertThat(keepImage.getImagePriority()).isEqualTo(1);
+            assertThat(keepFile.getFilePriority()).isEqualTo(2);
+            verify(memoImageRepository, never()).deleteAllByIdInBatch(anyList());
+            verify(memoFileRepository, never()).deleteAllByIdInBatch(anyList());
+        }
+
+        @Test
+        @DisplayName("유지 항목만 있으면 S3 메타데이터를 조회하지 않는다")
+        void updateMemo_keepOnly_doesNotQueryS3Metadata() {
+            // given: 자동저장처럼 첨부 변경 없이 본문만 수정
+            Memo memo = ownedMemo("제목", "내용");
+            MemoImage keep = MemoImage.builder()
+                    .id(10L).memo(memo).imageS3Key("memo-image/1/keep.png").imagePriority(0).build();
+            memo.getMemoImages().add(keep);
+            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+
+            MemoUpdateRequest.ImageEdit keepEdit =
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 0);
+            MemoUpdateRequest req =
+                    new MemoUpdateRequest("제목", "새 내용", List.of(), List.of(keepEdit), List.of());
+
+            // when
+            memoService.updateMemo(userId, memoId, req);
+
+            // then
+            verify(s3Util, never()).getObjectMetadata(anyString());
+            verify(s3KeyUtil, never()).validateS3Key(anyLong(), anyString(), anyString());
         }
     }
 }

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -122,7 +122,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.ImageRequest(
                             "memo-image/1/test.png",
                             "test.png",
-                            "png",
                             1
                     );
 
@@ -130,7 +129,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.FileRequest(
                             "memo-file/1/test.pdf",
                             "test.pdf",
-                            "pdf",
                             1
                     );
 
@@ -170,12 +168,12 @@ class MemoServiceImplTest {
             given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             List<MemoCreateRequest.ImageRequest> images = List.of(
-                    new MemoCreateRequest.ImageRequest("memo-image/1/1.png", "1.png", "png", 1),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/2.png", "2.png", "png", 2),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/3.png", "3.png", "png", 3),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/4.png", "4.png", "png", 4),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/5.png", "5.png", "png", 5),
-                    new MemoCreateRequest.ImageRequest("memo-image/1/6.png", "6.png", "png", 6)
+                    new MemoCreateRequest.ImageRequest("memo-image/1/1.png", "1.png", 1),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/2.png", "2.png", 2),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/3.png", "3.png", 3),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/4.png", "4.png", 4),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/5.png", "5.png", 5),
+                    new MemoCreateRequest.ImageRequest("memo-image/1/6.png", "6.png", 6)
             );
 
             MemoCreateRequest tooManyImagesRequest = new MemoCreateRequest(
@@ -197,7 +195,7 @@ class MemoServiceImplTest {
             given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
             List<MemoCreateRequest.FileRequest> files = List.of(
-                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", "pdf", 1)
+                    new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", 1)
             );
             given(s3Util.getObjectMetadata("memo-file/1/1.pdf"))
                     .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
@@ -291,7 +289,6 @@ class MemoServiceImplTest {
                     new MemoCreateRequest.ImageRequest(
                             "memo-image/999/invalid.png",
                             "invalid.png",
-                            "png",
                             1
                     );
 
@@ -749,6 +746,70 @@ class MemoServiceImplTest {
     @Nested
     @DisplayName("Presigned URL 발급 테스트")
     class issuePresignedUrls {
+
+        @Test
+        @DisplayName("이미지 확장자가 허용 목록에 없으면 UNSUPPORTED_EXTENSION 예외가 발생한다")
+        void issuePresignedUrls_UnsupportedImageExtension_throws() {
+            // given: 확장자는 그대로 s3Key에 박히고 저장 시 다시 읽히므로 발급 시점에 막는다
+            var request = new MemoPresignedUrlRequest(
+                    List.of(new MemoPresignedUrlRequest.UploadRequest("exe", 1024L, 1)),
+                    List.of()
+            );
+
+            // when & then
+            assertThatThrownBy(() -> memoService.issuePresignedUrls(userId, request))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.UNSUPPORTED_EXTENSION);
+
+            verify(s3Util, never()).createPresignedPutUrl(anyLong(), anyString(), anyString(), anyLong(), anyInt());
+        }
+
+        @Test
+        @DisplayName("파일 확장자가 허용 목록에 없으면 UNSUPPORTED_EXTENSION 예외가 발생한다")
+        void issuePresignedUrls_UnsupportedFileExtension_throws() {
+            // given
+            var request = new MemoPresignedUrlRequest(
+                    List.of(),
+                    List.of(new MemoPresignedUrlRequest.UploadRequest("sh", 1024L, 1))
+            );
+
+            // when & then
+            assertThatThrownBy(() -> memoService.issuePresignedUrls(userId, request))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.UNSUPPORTED_EXTENSION);
+        }
+
+        @Test
+        @DisplayName("hwp 등 문서 확장자는 허용한다")
+        void issuePresignedUrls_DocumentExtensions_allowed() {
+            // given: Tika가 파싱하지 못하더라도 첨부 자체는 허용한다
+            var request = new MemoPresignedUrlRequest(
+                    List.of(),
+                    List.of(new MemoPresignedUrlRequest.UploadRequest("hwp", 1024L, 1))
+            );
+            given(s3Util.createPresignedPutUrl(eq(userId), eq("memo-file"), eq("hwp"), eq(1024L), eq(1)))
+                    .willReturn(new MemoPresignedUrlResponse.PresignedUrlResponse(
+                            "memo-file/1/uuid.hwp", "https://s3.url/file", 1024L, "hwp", 1));
+
+            // when & then
+            assertThat(memoService.issuePresignedUrls(userId, request).files()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("확장자 대소문자는 구분하지 않는다 (PNG 허용)")
+        void issuePresignedUrls_UpperCaseExtension_allowed() {
+            // given
+            var request = new MemoPresignedUrlRequest(
+                    List.of(new MemoPresignedUrlRequest.UploadRequest("PNG", 1024L, 1)),
+                    List.of()
+            );
+            given(s3Util.createPresignedPutUrl(eq(userId), eq("memo-image"), eq("PNG"), eq(1024L), eq(1)))
+                    .willReturn(new MemoPresignedUrlResponse.PresignedUrlResponse(
+                            "memo-image/1/uuid.PNG", "https://s3.url/image", 1024L, "PNG", 1));
+
+            // when & then
+            assertThat(memoService.issuePresignedUrls(userId, request).images()).hasSize(1);
+        }
 
         @Test
         @DisplayName("이미지와 파일 확장자 정보를 보내면 S3Util을 통해 URL 목록을 발급한다.")
@@ -1279,7 +1340,7 @@ class MemoServiceImplTest {
                     });
 
             MemoUpdateRequest.ImageEdit newImage =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of());
 
@@ -1306,7 +1367,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit keepEdit =
-                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(keepEdit), List.of());
 
@@ -1335,7 +1396,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit keepEdit =
-                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 3);
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, 3);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(keepEdit), List.of());
 
@@ -1358,10 +1419,10 @@ class MemoServiceImplTest {
                 MemoImage img = MemoImage.builder()
                         .id(i).memo(memo).imageS3Key("memo-image/1/" + i + ".png").imagePriority((int) i).build();
                 memo.getMemoImages().add(img);
-                edits.add(new MemoUpdateRequest.ImageEdit(i, null, null, null, (int) i));
+                edits.add(new MemoUpdateRequest.ImageEdit(i, null, null, (int) i));
             }
             for (int i = 0; i < 3; i++) {
-                edits.add(new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new" + i + ".png", "n.png", "png", i));
+                edits.add(new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new" + i + ".png", "n.png", i));
             }
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
@@ -1381,7 +1442,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit bad =
-                    new MemoUpdateRequest.ImageEdit(null, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(bad), List.of());
 
@@ -1402,7 +1463,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit ambiguous =
-                    new MemoUpdateRequest.ImageEdit(10L, "memo-image/1/new.png", "new.png", "png", 0);
+                    new MemoUpdateRequest.ImageEdit(10L, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(ambiguous), List.of());
 
@@ -1420,7 +1481,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.FileEdit bad =
-                    new MemoUpdateRequest.FileEdit(null, null, null, null, 0);
+                    new MemoUpdateRequest.FileEdit(null, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(bad));
 
@@ -1438,7 +1499,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit ghost =
-                    new MemoUpdateRequest.ImageEdit(999L, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(999L, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(ghost), List.of());
 
@@ -1460,9 +1521,9 @@ class MemoServiceImplTest {
                     .willReturn(new S3Util.S3ObjectMetadata(4_000L, "application/pdf"));
 
             MemoUpdateRequest.ImageEdit newImage =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest.FileEdit newFile =
-                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of(newFile));
 
@@ -1489,7 +1550,7 @@ class MemoServiceImplTest {
                     .willReturn(new S3Util.S3ObjectMetadata(5L * 1024 * 1024 + 1, "image/png"));
 
             MemoUpdateRequest.ImageEdit huge =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/huge.png", "huge.png", "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/huge.png", "huge.png", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(huge), List.of());
 
@@ -1511,7 +1572,7 @@ class MemoServiceImplTest {
                     .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
 
             MemoUpdateRequest.FileEdit huge =
-                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/huge.pdf", "huge.pdf", "pdf", 0);
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/huge.pdf", "huge.pdf", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(huge));
 
@@ -1531,9 +1592,9 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit newImage =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest.FileEdit newFile =
-                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", "new.pdf", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of(newFile));
 
@@ -1556,7 +1617,7 @@ class MemoServiceImplTest {
                     .validateS3Key(eq(userId), eq("memo-image"), anyString());
 
             MemoUpdateRequest.ImageEdit crossed =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-file/1/new.pdf", "new.pdf", "pdf", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-file/1/new.pdf", "new.pdf", 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(crossed), List.of());
 
@@ -1576,7 +1637,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit noName =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", null, "png", 0);
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(noName), List.of());
 
@@ -1589,21 +1650,27 @@ class MemoServiceImplTest {
         }
 
         @Test
-        @DisplayName("새 이미지에 extension이 비어 있으면 MISSING_ATTACHMENT_METADATA 예외가 발생한다")
-        void updateMemo_addImageWithBlankExtension_throws() {
+        @DisplayName("새 첨부의 확장자는 요청이 아니라 s3Key에서 뽑아 저장한다")
+        void updateMemo_addedAttachment_extensionParsedFromS3Key() {
             // given
             Memo memo = ownedMemo("제목", "내용");
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
+            given(s3Util.getObjectMetadata("memo-image/1/new.png"))
+                    .willReturn(new S3Util.S3ObjectMetadata(3_000L, "image/png"));
+            given(s3KeyUtil.extractExtension("memo-image/1/new.png")).willReturn("png");
 
-            MemoUpdateRequest.ImageEdit blankExt =
-                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", "  ", 0);
+            MemoUpdateRequest.ImageEdit newImage =
+                    new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest req =
-                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(blankExt), List.of());
+                    new MemoUpdateRequest("제목", "내용", List.of(), List.of(newImage), List.of());
 
-            // when & then
-            assertThatThrownBy(() -> memoService.updateMemo(userId, memoId, req))
-                    .isInstanceOf(MemoException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+            // when
+            memoService.updateMemo(userId, memoId, req);
+
+            // then
+            ArgumentCaptor<List<MemoImage>> captor = ArgumentCaptor.forClass(List.class);
+            verify(memoImageRepository).saveAll(captor.capture());
+            assertThat(captor.getValue().get(0).getImageExtension()).isEqualTo("png");
         }
 
         @Test
@@ -1614,7 +1681,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.FileEdit noName =
-                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", null, "pdf", 0);
+                    new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "내용", List.of(), List.of(), List.of(noName));
 
@@ -1641,8 +1708,8 @@ class MemoServiceImplTest {
 
             MemoUpdateRequest req = new MemoUpdateRequest(
                     "제목", "내용", List.of(),
-                    List.of(new MemoUpdateRequest.ImageEdit(10L, null, null, null, 1)),
-                    List.of(new MemoUpdateRequest.FileEdit(20L, null, null, null, 2))
+                    List.of(new MemoUpdateRequest.ImageEdit(10L, null, null, 1)),
+                    List.of(new MemoUpdateRequest.FileEdit(20L, null, null, 2))
             );
 
             // when
@@ -1666,7 +1733,7 @@ class MemoServiceImplTest {
             given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
 
             MemoUpdateRequest.ImageEdit keepEdit =
-                    new MemoUpdateRequest.ImageEdit(10L, null, null, null, 0);
+                    new MemoUpdateRequest.ImageEdit(10L, null, null, 0);
             MemoUpdateRequest req =
                     new MemoUpdateRequest("제목", "새 내용", List.of(), List.of(keepEdit), List.of());
 

--- a/src/test/java/org/project/global/util/S3KeyUtilTest.java
+++ b/src/test/java/org/project/global/util/S3KeyUtilTest.java
@@ -1,0 +1,70 @@
+package org.project.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.global.exception.domainException.MemoException;
+import org.project.global.exception.errorcode.MemoErrorCode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("S3KeyUtil 테스트")
+class S3KeyUtilTest {
+
+    private final S3KeyUtil s3KeyUtil = new S3KeyUtil();
+
+    @Nested
+    @DisplayName("확장자 추출")
+    class ExtractExtension {
+
+        @Test
+        @DisplayName("s3Key 끝의 확장자를 소문자로 반환한다")
+        void extractExtension_returnsLowerCase() {
+            assertThat(s3KeyUtil.extractExtension("memo-image/1/uuid.png")).isEqualTo("png");
+            assertThat(s3KeyUtil.extractExtension("memo-image/1/uuid.PNG")).isEqualTo("png");
+            assertThat(s3KeyUtil.extractExtension("memo-file/12/uuid.pdf")).isEqualTo("pdf");
+        }
+
+        @Test
+        @DisplayName("파일명에 점이 여러 개면 마지막 것을 확장자로 본다")
+        void extractExtension_multipleDots() {
+            assertThat(s3KeyUtil.extractExtension("memo-file/1/my.report.v2.pdf")).isEqualTo("pdf");
+        }
+
+        @Test
+        @DisplayName("확장자가 없으면 INVALID_S3_KEY_FORMAT 예외가 발생한다")
+        void extractExtension_noExtension_throws() {
+            assertThatThrownBy(() -> s3KeyUtil.extractExtension("memo-image/1/uuid"))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        @Test
+        @DisplayName("점으로 끝나면 INVALID_S3_KEY_FORMAT 예외가 발생한다")
+        void extractExtension_trailingDot_throws() {
+            assertThatThrownBy(() -> s3KeyUtil.extractExtension("memo-image/1/uuid."))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        @Test
+        @DisplayName("경로에만 점이 있고 파일명에 없으면 INVALID_S3_KEY_FORMAT 예외가 발생한다")
+        void extractExtension_dotOnlyInPath_throws() {
+            assertThatThrownBy(() -> s3KeyUtil.extractExtension("memo.image/1/uuid"))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+
+        @Test
+        @DisplayName("null이거나 빈 값이면 INVALID_S3_KEY_FORMAT 예외가 발생한다")
+        void extractExtension_blank_throws() {
+            assertThatThrownBy(() -> s3KeyUtil.extractExtension(null))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+            assertThatThrownBy(() -> s3KeyUtil.extractExtension("  "))
+                    .isInstanceOf(MemoException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MemoErrorCode.INVALID_S3_KEY_FORMAT);
+        }
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #185

## 📝 Summary

메모 첨부(이미지/파일) 메타데이터 검증을 정리했습니다.

- **파일명 필수화** — 검증이 없어서 `s3Key`만 보내면 파일명·확장자가 null로 저장되던 문제 수정 (생성/수정 모두)
- **`bytes` 제거** — 클라이언트가 보낸 크기 대신 S3 실제 객체 크기(`HeadObject`)를 읽어 저장. 요청 필드에서 삭제
- **`extension` 제거** — `s3Key`(`memo-image/{userId}/{uuid}.png`)에서 파싱해 저장. 요청 필드에서 삭제
- **presigned 발급 시 확장자 화이트리스트 검증 추가** — 발급 시점 확장자가 그대로 s3Key에 들어가고 저장 시 다시 읽히므로 여기서 차단
- **메모 수정(PATCH) 첨부 검증 보강** — 생성에만 있던 검증을 수정에도 동일하게 적용
  - 신규 추가분의 s3Key를 용도별 prefix(`memo-image`/`memo-file`)까지 교차 검증
  - 용량 제한도 클라이언트 값이 아닌 S3 실제 객체 크기 기준으로 검증
  - 유지 항목은 검증·조회 대상에서 제외 (이미 저장 시점에 검증 완료)
  - `priority`를 유지·추가 모두 필수로 (DB 컬럼이 `nullable = false`인데 요청 검증이 없었음)


첨부 요청 필드가 5개 → 3개(`s3Key`, 파일명, `priority`)로 줄었습니다.

## 🙏 Question & PR point


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 첨부파일의 실제 크기와 S3 키 기반 확장자를 자동으로 확인하고 저장합니다.
  * 이미지 및 파일 업로드 시 지원되는 확장자만 허용합니다.
  * 첨부파일 이름과 우선순위 등 필수 입력값 검증이 강화되었습니다.

* **버그 수정**
  * 잘못된 S3 키, 누락된 첨부 메타데이터, 지원하지 않는 확장자에 대해 명확한 오류를 제공합니다.
  * 첨부파일 수정 시 파일 크기와 소유 경로 검증이 개선되었습니다.

* **문서**
  * 첨부파일 응답 정보의 필수 항목 안내가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->