### PR TITLE
[Chore] S3 검증을 트랙잭션에서 분리

### DIFF
--- a/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
+++ b/src/main/java/org/project/domain/memo/dto/response/MemoPresignedUrlResponse.java
@@ -10,12 +10,31 @@ public record MemoPresignedUrlResponse(
         List<PresignedUrlResponse> files
 ) {
 
-    @Schema(requiredProperties = {"s3Key", "presignedUrl", "bytes", "extension", "priority"})
+    @Schema(requiredProperties = {"s3Key", "presignedUrl", "contentType", "bytes", "extension", "priority"})
     public record PresignedUrlResponse(
+            @Schema(description = "업로드 후 메모 저장 시 함께 보낼 S3 key", example = "memo-file/1/uuid.hwp")
             String s3Key,
+
+            @Schema(description = "이 URL로 PUT 업로드한다 (유효시간 10분)")
             String presignedUrl,
+
+            @Schema(
+                    description = """
+                            업로드(PUT) 시 `Content-Type` 헤더에 **이 값을 그대로** 넣어야 한다.
+                            presigned URL 서명에 포함된 값이라, 다른 값을 보내면 S3가 403(SignatureDoesNotMatch)을 반환한다.
+                            브라우저가 판단한 타입을 쓰지 말고 서버가 준 값을 그대로 되돌려줄 것.
+                            """,
+                    example = "application/octet-stream"
+            )
+            String contentType,
+
+            @Schema(description = "요청에서 받은 파일 크기", example = "102400")
             Long bytes,
+
+            @Schema(description = "요청에서 받은 확장자", example = "hwp")
             String extension,
+
+            @Schema(description = "요청에서 받은 정렬 우선순위", example = "0")
             Integer priority
     ) {
     }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -44,7 +44,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -70,6 +72,9 @@ public class MemoServiceImpl implements MemoService {
 
     private final S3KeyUtil s3KeyUtil;
     private final S3Util s3Util;
+
+    // S3 왕복을 트랜잭션 밖에서 끝내기 위해, 쓰기 구간만 명시적으로 트랜잭션에 넣는다.
+    private final TransactionTemplate transactionTemplate;
 
     private final ApplicationEventPublisher eventPublisher;
     private final MemoSearchVectorRetriever memoSearchVectorRetriever;
@@ -136,16 +141,29 @@ public class MemoServiceImpl implements MemoService {
         return new MemoPresignedUrlResponse(imageUrls, fileUrls);
     }
 
-    @Transactional
+    /**
+     * DB가 필요 없는 검증(개수·S3 실제 객체 확인)을 먼저 끝내고, 쓰기 구간만 트랜잭션으로 감싼다.
+     * S3 HeadObject는 네트워크 왕복이라, 트랜잭션 안에 두면 그 시간만큼 DB 커넥션을 점유한다.
+     * NOT_SUPPORTED는 클래스 레벨 @Transactional(readOnly = true)이 이 메서드에 걸리는 것을 막는다.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public MemoResponse createMemo(Long userId, MemoCreateRequest request) {
-
-        // 사용자 조회
-        User user = getUserOrThrow(userId);
 
         validateImageCount(request.images());
         validateFileCount(request.files());
         Map<String, Long> actualBytesByKey = validateUploadedMedia(userId, request);
+
+        return transactionTemplate.execute(status -> createMemoInTx(userId, request, actualBytesByKey));
+    }
+
+    private MemoResponse createMemoInTx(
+            Long userId,
+            MemoCreateRequest request,
+            Map<String, Long> actualBytesByKey
+    ) {
+        // 사용자 조회
+        User user = getUserOrThrow(userId);
 
         // 메모 생성
         Memo memo = Memo.createMemo(
@@ -176,10 +194,36 @@ public class MemoServiceImpl implements MemoService {
         return MemoResponse.from(savedMemo);
     }
 
-    @Transactional
+    /**
+     * createMemo와 같은 이유로 검증(요청 형태·S3 실제 객체)을 트랜잭션 밖에서 먼저 수행한다.
+     * 형태 검증을 S3 검증보다 앞에 두어야 기존 에러코드(INVALID_ATTACHMENT_EDIT 등)가 유지된다.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public MemoResponse updateMemo(Long userId, Long memoId, MemoUpdateRequest request) {
 
+        validateImageEditShape(request.images());
+        validateFileEditShape(request.files());
+
+        // 이미지·파일 신규 키를 한 번에 검증한다 (S3 왕복 1회)
+        Map<String, Long> actualBytesByKey = validateUploadedMedia(
+                userId,
+                newAttachmentKeys(request.images(),
+                        MemoUpdateRequest.ImageEdit::imageId, MemoUpdateRequest.ImageEdit::s3Key),
+                newAttachmentKeys(request.files(),
+                        MemoUpdateRequest.FileEdit::fileId, MemoUpdateRequest.FileEdit::s3Key)
+        );
+
+        return transactionTemplate.execute(
+                status -> updateMemoInTx(userId, memoId, request, actualBytesByKey));
+    }
+
+    private MemoResponse updateMemoInTx(
+            Long userId,
+            Long memoId,
+            MemoUpdateRequest request,
+            Map<String, Long> actualBytesByKey
+    ) {
         Memo memo = getMemoOrThrow(memoId);
         checkMyMemo(memo, userId);
 
@@ -199,8 +243,8 @@ public class MemoServiceImpl implements MemoService {
         }
 
         // 3) 첨부(이미지/파일) diff — 유지/추가/삭제
-        RemovedMedia removedImages = applyImageEdits(memo, request.images(), userId);
-        RemovedMedia removedFiles = applyFileEdits(memo, request.files(), userId);
+        RemovedMedia removedImages = applyImageEdits(memo, request.images(), userId, actualBytesByKey);
+        RemovedMedia removedFiles = applyFileEdits(memo, request.files(), userId, actualBytesByKey);
 
         // 4) updatedAt을 응답에 반영하기 위해 flush (dirty checking → @LastModifiedDate 발동)
         memoRepository.flush();
@@ -232,18 +276,13 @@ public class MemoServiceImpl implements MemoService {
     }
 
     // 이미지 최종 상태를 현재 메모와 비교해 유지/추가/삭제 반영. 반환=삭제된 이미지 정보. (edits는 @NotNull 보장)
-    private RemovedMedia applyImageEdits(Memo memo, List<MemoUpdateRequest.ImageEdit> edits, Long userId) {
-        // 각 항목은 유지(imageId) 또는 추가(s3Key) 중 "정확히 하나"만 가져야 한다.
-        for (MemoUpdateRequest.ImageEdit e : edits) {
-            if ((e.imageId() == null) == (e.s3Key() == null)) {
-                throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
-            }
-            // 신규 추가분은 파일명이 필수(확장자는 s3Key에서 뽑는다). 유지분은 서버가 이미 보관하므로 요구하지 않는다.
-            if (e.s3Key() != null && isBlank(e.imageName())) {
-                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
-            }
-        }
-
+    private RemovedMedia applyImageEdits(
+            Memo memo,
+            List<MemoUpdateRequest.ImageEdit> edits,
+            Long userId,
+            Map<String, Long> actualBytesByKey
+    ) {
+        // 요청 형태·개수 검증과 S3 확인은 트랜잭션 밖(updateMemo)에서 이미 끝났다.
         Map<Long, MemoImage> existingById = memo.getMemoImages().stream()
                 .collect(Collectors.toMap(MemoImage::getId, Function.identity()));
 
@@ -260,17 +299,6 @@ public class MemoServiceImpl implements MemoService {
                 throw new MemoException(MemoErrorCode.MEMO_IMAGE_NOT_FOUND);
             }
         }
-
-        // 최종 개수/용량 검증
-        if (keepEdits.size() + addEdits.size() > MAX_IMAGE_COUNT) {
-            throw new MemoException(MemoErrorCode.TOO_MANY_IMAGES);
-        }
-        // 신규 추가분만 S3 실제 객체 기준으로 검증 (유지분은 저장 시점에 검증 완료)
-        Map<String, Long> actualBytesByKey = validateUploadedMedia(
-                userId,
-                extractS3Keys(addEdits, MemoUpdateRequest.ImageEdit::s3Key),
-                List.of()
-        );
 
         // 유지 이미지 우선순위 갱신
         keepEdits.forEach(e -> existingById.get(e.imageId()).updatePriority(e.priority()));
@@ -315,19 +343,13 @@ public class MemoServiceImpl implements MemoService {
     }
 
     // 파일 최종 상태를 현재 메모와 비교해 유지/추가/삭제 반영. 반환=삭제된 파일 정보. (edits는 @NotNull 보장)
-    private RemovedMedia applyFileEdits(Memo memo, List<MemoUpdateRequest.FileEdit> edits, Long userId) {
-        // 각 항목은 유지(fileId) 또는 추가(s3Key) 중 "정확히 하나"만 가져야 한다.
-        // 둘 다 null(정체불명) 또는 둘 다 있음(유지/추가 모호) → 거부.
-        for (MemoUpdateRequest.FileEdit e : edits) {
-            if ((e.fileId() == null) == (e.s3Key() == null)) {
-                throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
-            }
-            // 신규 추가분은 파일명이 필수(확장자는 s3Key에서 뽑는다). 유지분은 서버가 이미 보관하므로 요구하지 않는다.
-            if (e.s3Key() != null && isBlank(e.fileName())) {
-                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
-            }
-        }
-
+    private RemovedMedia applyFileEdits(
+            Memo memo,
+            List<MemoUpdateRequest.FileEdit> edits,
+            Long userId,
+            Map<String, Long> actualBytesByKey
+    ) {
+        // 요청 형태·개수 검증과 S3 확인은 트랜잭션 밖(updateMemo)에서 이미 끝났다.
         Map<Long, MemoFile> existingById = memo.getMemoFiles().stream()
                 .collect(Collectors.toMap(MemoFile::getId, Function.identity()));
 
@@ -343,16 +365,6 @@ public class MemoServiceImpl implements MemoService {
                 throw new MemoException(MemoErrorCode.MEMO_FILE_NOT_FOUND);
             }
         }
-
-        if (keepEdits.size() + addEdits.size() > MAX_FILE_COUNT) {
-            throw new MemoException(MemoErrorCode.TOO_MANY_FILES);
-        }
-        // 신규 추가분만 S3 실제 객체 기준으로 검증 (유지분은 저장 시점에 검증 완료)
-        Map<String, Long> actualBytesByKey = validateUploadedMedia(
-                userId,
-                List.of(),
-                extractS3Keys(addEdits, MemoUpdateRequest.FileEdit::s3Key)
-        );
 
         keepEdits.forEach(e -> existingById.get(e.fileId()).updatePriority(e.priority()));
 
@@ -983,6 +995,55 @@ public class MemoServiceImpl implements MemoService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    /**
+     * 요청만으로 판단 가능한 이미지 수정 항목 검증. DB·S3 접근이 없어 트랜잭션 밖에서 수행한다.
+     * 각 항목은 유지(imageId) 또는 추가(s3Key) 중 "정확히 하나"만 가져야 한다.
+     */
+    private void validateImageEditShape(List<MemoUpdateRequest.ImageEdit> edits) {
+        for (MemoUpdateRequest.ImageEdit e : edits) {
+            if ((e.imageId() == null) == (e.s3Key() == null)) {
+                throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
+            }
+            // 신규 추가분은 파일명이 필수(확장자는 s3Key에서 뽑는다). 유지분은 서버가 이미 보관하므로 요구하지 않는다.
+            if (e.s3Key() != null && isBlank(e.imageName())) {
+                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+            }
+        }
+        // 최종 개수 = 유지 + 추가 = 요청 항목 수
+        if (edits.size() > MAX_IMAGE_COUNT) {
+            throw new MemoException(MemoErrorCode.TOO_MANY_IMAGES);
+        }
+    }
+
+    private void validateFileEditShape(List<MemoUpdateRequest.FileEdit> edits) {
+        for (MemoUpdateRequest.FileEdit e : edits) {
+            if ((e.fileId() == null) == (e.s3Key() == null)) {
+                throw new MemoException(MemoErrorCode.INVALID_ATTACHMENT_EDIT);
+            }
+            if (e.s3Key() != null && isBlank(e.fileName())) {
+                throw new MemoException(MemoErrorCode.MISSING_ATTACHMENT_METADATA);
+            }
+        }
+        if (edits.size() > MAX_FILE_COUNT) {
+            throw new MemoException(MemoErrorCode.TOO_MANY_FILES);
+        }
+    }
+
+    // 신규 추가분(기존 id가 없는 항목)의 s3Key만 모은다.
+    private <T> List<String> newAttachmentKeys(
+            List<T> edits,
+            Function<T, Long> idExtractor,
+            Function<T, String> keyExtractor
+    ) {
+        if (edits == null) {
+            return List.of();
+        }
+        return edits.stream()
+                .filter(e -> idExtractor.apply(e) == null)
+                .map(keyExtractor)
+                .toList();
     }
 
     private <T> List<String> extractS3Keys(List<T> items, Function<T, String> keyExtractor) {

--- a/src/main/java/org/project/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/project/global/config/swagger/SwaggerResponseDescription.java
@@ -24,6 +24,7 @@ public enum SwaggerResponseDescription {
             MemoErrorCode.MEMO_IMAGE_NOT_FOUND,
             MemoErrorCode.MEMO_FILE_NOT_FOUND,
             MemoErrorCode.INVALID_ATTACHMENT_EDIT,
+            MemoErrorCode.MISSING_ATTACHMENT_METADATA,
             MemoErrorCode.TOO_MANY_IMAGES,
             MemoErrorCode.TOO_MANY_FILES,
             MemoErrorCode.IMAGE_TOO_LARGE,
@@ -86,7 +87,12 @@ public enum SwaggerResponseDescription {
     ))),
 
     GET_PRESIGNED_URLS(new LinkedHashSet<>(Set.of(
-            S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED
+            S3ErrorCode.PRESIGNED_URL_GENERATION_FAILED,
+            MemoErrorCode.UNSUPPORTED_EXTENSION,
+            MemoErrorCode.TOO_MANY_IMAGES,
+            MemoErrorCode.TOO_MANY_FILES,
+            MemoErrorCode.IMAGE_TOO_LARGE,
+            MemoErrorCode.FILE_TOO_LARGE
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/project/global/util/S3Util.java
+++ b/src/main/java/org/project/global/util/S3Util.java
@@ -164,10 +164,14 @@ public class S3Util {
                 extension
         );
 
+        // 이 값은 presigned URL 서명에 포함된다. 클라이언트가 PUT할 때 Content-Type 헤더로
+        // 똑같이 보내야 서명이 맞으므로, 응답에 그대로 실어 내려준다.
+        String contentType = resolveMimeTypeByExtension(extension).toString();
+
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(s3Key)
-                .contentType(resolveMimeTypeByExtension(extension).toString())
+                .contentType(contentType)
                 .build();
 
         PutObjectPresignRequest presignRequest =
@@ -184,6 +188,7 @@ public class S3Util {
         return new MemoPresignedUrlResponse.PresignedUrlResponse(
                 s3Key,
                 presignedUrl,
+                contentType,
                 bytes,
                 extension,
                 priority

--- a/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
+++ b/src/test/java/org/project/domain/memo/controller/MemoControllerTest.java
@@ -108,8 +108,8 @@ class MemoControllerTest {
 
             // 예상 응답 데이터 생성
             MemoPresignedUrlResponse expectedResponse = new MemoPresignedUrlResponse(
-                    List.of(new MemoPresignedUrlResponse.PresignedUrlResponse("img-key", "http://s3/img", 1024L, "jpg", 1)),
-                    List.of(new MemoPresignedUrlResponse.PresignedUrlResponse("file-key", "http://s3/file", 2048L, "pdf", 1))
+                    List.of(new MemoPresignedUrlResponse.PresignedUrlResponse("img-key", "http://s3/img", "image/jpeg", 1024L, "jpg", 1)),
+                    List.of(new MemoPresignedUrlResponse.PresignedUrlResponse("file-key", "http://s3/file", "application/pdf", 2048L, "pdf", 1))
             );
 
             when(memoService.issuePresignedUrls(eq(userId), any(MemoPresignedUrlRequest.class)))
@@ -144,7 +144,7 @@ class MemoControllerTest {
             MemoPresignedUrlResponse expectedResponse = new MemoPresignedUrlResponse(
                     List.of(
                             new MemoPresignedUrlResponse.PresignedUrlResponse(
-                                    "img-key", "http://s3/img", 2048L, "png", 1)
+                                    "img-key", "http://s3/img", "image/png", 2048L, "png", 1)
                     ),
                     List.of()
             );
@@ -186,7 +186,7 @@ class MemoControllerTest {
                     List.of(),
                     List.of(
                             new MemoPresignedUrlResponse.PresignedUrlResponse(
-                                    "file-key", "http://s3/file", 5120L, "pdf", 1)
+                                    "file-key", "http://s3/file", "application/pdf", 5120L, "pdf", 1)
                     )
             );
 

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -48,6 +48,8 @@ import org.project.global.util.S3Util;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -79,6 +81,7 @@ class MemoServiceImplTest {
 
     @Mock private S3KeyUtil s3KeyUtil;
     @Mock private S3Util s3Util;
+    @Mock private TransactionTemplate transactionTemplate;
 
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private MemoSearchVectorRetriever memoSearchVectorRetriever;
@@ -89,6 +92,15 @@ class MemoServiceImplTest {
     // 공통 테스트 데이터 상수
     private final Long userId = 1L;
     private final Long memoId = 100L;
+
+    // 쓰기 경로는 트랜잭션 밖에서 검증한 뒤 TransactionTemplate으로 감싸므로,
+    // 단위 테스트에서는 콜백을 그 자리에서 실행시켜 기존과 같은 흐름으로 검증한다.
+    @BeforeEach
+    void runTransactionTemplateInline() {
+        lenient().when(transactionTemplate.execute(any()))
+                .thenAnswer(invocation -> ((TransactionCallback<?>) invocation.getArgument(0))
+                        .doInTransaction(null));
+    }
 
     @Nested
     @DisplayName("createMemo")
@@ -165,8 +177,6 @@ class MemoServiceImplTest {
         @Test
         @DisplayName("이미지 개수가 5개를 초과하면 예외가 발생한다.")
         void createMemo_TooManyImages() {
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-
             List<MemoCreateRequest.ImageRequest> images = List.of(
                     new MemoCreateRequest.ImageRequest("memo-image/1/1.png", "1.png", 1),
                     new MemoCreateRequest.ImageRequest("memo-image/1/2.png", "2.png", 2),
@@ -192,8 +202,6 @@ class MemoServiceImplTest {
         @Test
         @DisplayName("S3 실제 파일 용량이 제한을 초과하면 예외가 발생한다.")
         void createMemo_FileTooLarge() {
-            given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-
             List<MemoCreateRequest.FileRequest> files = List.of(
                     new MemoCreateRequest.FileRequest("memo-file/1/1.pdf", "1.pdf", 1)
             );
@@ -299,10 +307,6 @@ class MemoServiceImplTest {
                     List.of(imageRequest),
                     List.of()
             );
-
-            // 사용자 조회 OK
-            when(userRepository.findById(userId))
-                    .thenReturn(Optional.of(user));
 
             // S3Key 검증 실패 강제
             doThrow(new MemoException(MemoErrorCode.S3_KEY_USER_MISMATCH))
@@ -1424,8 +1428,6 @@ class MemoServiceImplTest {
             for (int i = 0; i < 3; i++) {
                 edits.add(new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new" + i + ".png", "n.png", i));
             }
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest req = new MemoUpdateRequest("제목", "내용", List.of(), edits, List.of());
 
             // when & then
@@ -1439,8 +1441,6 @@ class MemoServiceImplTest {
         void updateMemo_imageEditBothNull_throws() {
             // given: 배열 안 원소가 유지(id)도 추가(s3Key)도 아님
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest.ImageEdit bad =
                     new MemoUpdateRequest.ImageEdit(null, null, null, 0);
             MemoUpdateRequest req =
@@ -1460,8 +1460,6 @@ class MemoServiceImplTest {
             MemoImage existing = MemoImage.builder()
                     .id(10L).memo(memo).imageS3Key("memo-image/1/keep.png").imagePriority(0).build();
             memo.getMemoImages().add(existing);
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest.ImageEdit ambiguous =
                     new MemoUpdateRequest.ImageEdit(10L, "memo-image/1/new.png", "new.png", 0);
             MemoUpdateRequest req =
@@ -1478,8 +1476,6 @@ class MemoServiceImplTest {
         void updateMemo_fileEditBothNull_throws() {
             // given
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest.FileEdit bad =
                     new MemoUpdateRequest.FileEdit(null, null, null, 0);
             MemoUpdateRequest req =
@@ -1545,7 +1541,6 @@ class MemoServiceImplTest {
         void updateMemo_addedImageActuallyTooLarge_throws() {
             // given: 실제 객체가 5MB 초과
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
             given(s3Util.getObjectMetadata("memo-image/1/huge.png"))
                     .willReturn(new S3Util.S3ObjectMetadata(5L * 1024 * 1024 + 1, "image/png"));
 
@@ -1567,7 +1562,6 @@ class MemoServiceImplTest {
         void updateMemo_addedFileActuallyTooLarge_throws() {
             // given
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
             given(s3Util.getObjectMetadata("memo-file/1/huge.pdf"))
                     .willReturn(new S3Util.S3ObjectMetadata(10L * 1024 * 1024 + 1, "application/pdf"));
 
@@ -1611,7 +1605,6 @@ class MemoServiceImplTest {
         void updateMemo_invalidS3KeyPrefix_doesNotSave() {
             // given: 이미지 자리에 파일 key를 넣은 요청
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
             doThrow(new MemoException(MemoErrorCode.INVALID_S3_KEY_FORMAT))
                     .when(s3KeyUtil)
                     .validateS3Key(eq(userId), eq("memo-image"), anyString());
@@ -1634,8 +1627,6 @@ class MemoServiceImplTest {
         void updateMemo_addImageWithoutName_throws() {
             // given
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest.ImageEdit noName =
                     new MemoUpdateRequest.ImageEdit(null, "memo-image/1/new.png", null, 0);
             MemoUpdateRequest req =
@@ -1678,8 +1669,6 @@ class MemoServiceImplTest {
         void updateMemo_addFileWithoutName_throws() {
             // given
             Memo memo = ownedMemo("제목", "내용");
-            given(memoRepository.findByIdAndNotDeleted(memoId)).willReturn(Optional.of(memo));
-
             MemoUpdateRequest.FileEdit noName =
                     new MemoUpdateRequest.FileEdit(null, "memo-file/1/new.pdf", null, 0);
             MemoUpdateRequest req =

--- a/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoServiceImplTest.java
@@ -789,7 +789,7 @@ class MemoServiceImplTest {
             );
             given(s3Util.createPresignedPutUrl(eq(userId), eq("memo-file"), eq("hwp"), eq(1024L), eq(1)))
                     .willReturn(new MemoPresignedUrlResponse.PresignedUrlResponse(
-                            "memo-file/1/uuid.hwp", "https://s3.url/file", 1024L, "hwp", 1));
+                            "memo-file/1/uuid.hwp", "https://s3.url/file", "application/octet-stream", 1024L, "hwp", 1));
 
             // when & then
             assertThat(memoService.issuePresignedUrls(userId, request).files()).hasSize(1);
@@ -805,7 +805,7 @@ class MemoServiceImplTest {
             );
             given(s3Util.createPresignedPutUrl(eq(userId), eq("memo-image"), eq("PNG"), eq(1024L), eq(1)))
                     .willReturn(new MemoPresignedUrlResponse.PresignedUrlResponse(
-                            "memo-image/1/uuid.PNG", "https://s3.url/image", 1024L, "PNG", 1));
+                            "memo-image/1/uuid.PNG", "https://s3.url/image", "image/png", 1024L, "PNG", 1));
 
             // when & then
             assertThat(memoService.issuePresignedUrls(userId, request).images()).hasSize(1);
@@ -825,9 +825,9 @@ class MemoServiceImplTest {
 
             // S3Util이 반환할 가짜 응답 데이터 준비
             var mockImageRes = new MemoPresignedUrlResponse.PresignedUrlResponse(
-                    "memo-image/1/uuid.jpg", "https://s3.url/image", 1024L, "jpg", 1);
+                    "memo-image/1/uuid.jpg", "https://s3.url/image", "image/jpeg", 1024L, "jpg", 1);
             var mockFileRes = new MemoPresignedUrlResponse.PresignedUrlResponse(
-                    "memo-file/1/uuid.pdf", "https://s3.url/file", 2048L, "pdf", 2);
+                    "memo-file/1/uuid.pdf", "https://s3.url/file", "application/pdf", 2048L, "pdf", 2);
 
             // Mock 행동 설정
             given(s3Util.createPresignedPutUrl(eq(userId), eq("memo-image"), eq("jpg"), eq(1024L), eq(1)))

--- a/src/test/java/org/project/global/util/S3UtilPresignTest.java
+++ b/src/test/java/org/project/global/util/S3UtilPresignTest.java
@@ -1,0 +1,69 @@
+package org.project.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.memo.dto.response.MemoPresignedUrlResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * presigned PUT URL은 Content-Type을 서명에 포함하므로, 클라이언트가 그 값을 그대로
+ * 보내지 않으면 S3가 403(SignatureDoesNotMatch)을 준다. 따라서 응답의 contentType이
+ * 실제로 서명된 값과 일치해야 한다. presign은 네트워크 없이 로컬 계산이라 테스트 가능하다.
+ */
+@DisplayName("Presigned PUT URL 서명 테스트")
+class S3UtilPresignTest {
+
+    private final S3Util s3Util = newS3Util();
+
+    private S3Util newS3Util() {
+        S3Presigner presigner = S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("AKIAEXAMPLEEXAMPLE", "secretsecretsecret")))
+                .build();
+
+        S3Util util = new S3Util(null, presigner);
+        ReflectionTestUtils.setField(util, "bucket", "clustar-bucket-01");
+        return util;
+    }
+
+    private String signedHeadersOf(String url) {
+        String decoded = URLDecoder.decode(url, StandardCharsets.UTF_8);
+        int start = decoded.indexOf("X-Amz-SignedHeaders=") + "X-Amz-SignedHeaders=".length();
+        int end = decoded.indexOf('&', start);
+        return end == -1 ? decoded.substring(start) : decoded.substring(start, end);
+    }
+
+    @Test
+    @DisplayName("응답의 contentType은 URL에 실제로 서명된 값과 일치한다")
+    void createPresignedPutUrl_contentTypeMatchesSignature() {
+        // given: 서버 매핑에 없는 확장자 — 이때가 클라이언트 판단값과 어긋나기 쉽다
+        MemoPresignedUrlResponse.PresignedUrlResponse response =
+                s3Util.createPresignedPutUrl(1L, "memo-file", "hwp", 102_400L, 0);
+
+        // then: content-type이 서명 대상에 포함되어 있고(= 클라가 반드시 맞춰 보내야 하고)
+        assertThat(signedHeadersOf(response.presignedUrl())).contains("content-type");
+
+        // 응답이 그 값을 그대로 알려준다
+        assertThat(response.contentType()).isEqualTo("application/octet-stream");
+        assertThat(response.s3Key()).startsWith("memo-file/1/").endsWith(".hwp");
+    }
+
+    @Test
+    @DisplayName("서버 매핑에 있는 확장자는 해당 MIME 타입을 내려준다")
+    void createPresignedPutUrl_knownExtension() {
+        assertThat(s3Util.createPresignedPutUrl(1L, "memo-image", "png", 1L, 0).contentType())
+                .isEqualTo("image/png");
+        assertThat(s3Util.createPresignedPutUrl(1L, "memo-file", "pdf", 1L, 0).contentType())
+                .isEqualTo("application/pdf");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #187

## 📝 Summary

### 1. S3 검증을 트랜잭션 밖으로 분리

메모 생성·수정 시 S3 파일 확인(HeadObject)이 `@Transactional` 안에 있어, 네트워크 왕복 시간만큼 DB 커넥션을 점유하고 있었습니다.
DB가 필요 없는 검증(요청 형태·개수·S3 실제 객체 확인)을 트랜잭션 진입 전으로 옮기고, 쓰기 구간만 `TransactionTemplate`으로 감쌌습니다.
```
이전: [잡음] 조회 → 태그 → 형태검증 → S3확인 → S3확인 → 저장 [반납]
└───────────────┘
커넥션 잡은 채 대기

이후: 형태검증 → S3확인 → [잡음] 조회 → 태그 → 저장 [반납]
└──────────────┘
커넥션 없이 처리
```


- 커넥션 점유 시간이 **DB 작업 시간만큼**으로 단축
- 잘못된 요청은 **DB를 건드리지 않고** 400으로 종료
- 이미지·파일로 나뉘어 있던 S3 호출을 하나로 합쳐 **왕복 2회 → 1회**

**측정 결과** — 실제 컨텍스트를 띄우고 S3 호출 시점의 HikariCP 활성 커넥션 수를 확인했습니다.

| | S3 호출 시점 활성 커넥션 |
|---|---|
| 이전 | **1** (커넥션 잡은 채 대기) |
| 이후 | **0** |

### 2. presigned 응답에 `contentType` 추가

presigned PUT URL은 `Content-Type`을 서명에 포함합니다(`X-Amz-SignedHeaders=content-type;host`).
서버가 서명한 값을 클라이언트가 알 수 없어, 브라우저가 판단한 타입으로 PUT하면 403(`SignatureDoesNotMatch`)이 발생했습니다.
발급 응답에 서명한 값을 그대로 실어 내려, 클라이언트가 되돌려주기만 하면 항상 일치하도록 했습니다.

- 서명값과 응답값이 같은 변수에서 나오므로 어긋날 수 없음
- 회귀 방지 테스트 추가 (`S3UtilPresignTest`) — presign은 네트워크 없이 로컬 계산이라 실제 URL을 만들어 검증

## 🙏 Question & PR point


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 파일 업로드용 Presigned URL 응답에 `Content-Type` 정보가 포함됩니다.
  * 클라이언트는 응답으로 받은 `Content-Type`을 사용해 업로드해야 하며, 확장자에 맞는 MIME 타입이 제공됩니다.
* **개선 사항**
  * 메모 생성·수정 시 첨부파일 검증과 저장 처리가 안정적으로 분리되어 처리됩니다.
  * 첨부파일 형식, 개수, 용량 및 누락된 메타데이터 관련 오류 안내가 API 문서에 보강되었습니다.
* **테스트**
  * 이미지·문서·알 수 없는 확장자에 대한 업로드 타입과 Presigned URL 동작 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->