### PR TITLE
[Feat] ai 패널 위한 API 추가

### DIFF
--- a/src/main/java/org/project/domain/ai/controller/ChatRoomController.java
+++ b/src/main/java/org/project/domain/ai/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package org.project.domain.ai.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
 import org.project.domain.ai.dto.response.ChatRoomListResponse;
 import org.project.domain.ai.dto.response.CreateChatRoomResponse;
 import org.project.domain.ai.entity.ChatRoom;
@@ -26,8 +27,17 @@ public class ChatRoomController {
 
 
     @Operation(
-            summary = "AI 채팅방 생성",
-            description = "새로운 AI 채팅방을 생성합니다.")
+            summary = "AI 채팅방 생성 (새 대화 시작)",
+            description = """
+                새로운 AI 채팅방을 생성합니다.
+
+                기존 활성 채팅방이 있으면 함께 정리합니다.
+                - 채팅방: soft delete
+                - 대화 컨텍스트(ChatMemory): 삭제
+
+                패널을 여는 용도로는 호출하지 마세요. 기존 대화가 삭제됩니다.
+                패널 진입 시에는 `GET /api/v1/chat-rooms/active`를 사용합니다.
+                """)
     @PostMapping
     public ResponseEntity<ApiResponse<CreateChatRoomResponse>> createChatRoom(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -37,6 +47,29 @@ public class ChatRoomController {
         return ResponseEntity.ok(
                 ApiResponse.ok(
                         CreateChatRoomResponse.of(chatRoom.getId())
+                )
+        );
+    }
+
+
+    @Operation(
+            summary = "활성 AI 채팅방 및 대화 조회",
+            description = """
+                AI 패널 진입 시 사용합니다.
+                활성 채팅방과 지금까지의 대화를 함께 반환합니다.
+
+                - 활성 채팅방이 없으면 새로 생성한 뒤 빈 대화를 반환합니다 (404 없음)
+                - `messages`가 비어 있으면 아직 전송한 프롬프트가 없다는 의미입니다
+                - `messages`는 대화 순서(오름차순)로 정렬됩니다
+                """
+    )
+    @GetMapping("/active")
+    public ResponseEntity<ApiResponse<ActiveChatRoomResponse>> getActiveConversation(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.ok(
+                        chatRoomService.getActiveConversation(userDetails.getUserId())
                 )
         );
     }
@@ -58,9 +91,15 @@ public class ChatRoomController {
     }
 
     @Operation(
-            summary = "최근 AI 채팅방 단일 조회",
-            description = "로그인한 사용자의 최근 AI 채팅방을 조회합니다."
+            summary = "[Deprecated] 최근 AI 채팅방 단일 조회",
+            description = """
+                로그인한 사용자의 최근 AI 채팅방을 조회합니다.
+
+                대화 내용을 함께 반환하는 `GET /api/v1/chat-rooms/active` 사용을 권장합니다.
+                """,
+            deprecated = true
     )
+    @Deprecated
     @GetMapping("/latest")
     public ResponseEntity<ApiResponse<ChatRoomListResponse.ChatRoomResponse>> findLatestChatRoomByUser(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/org/project/domain/ai/dto/request/MemoAiRequest.java
+++ b/src/main/java/org/project/domain/ai/dto/request/MemoAiRequest.java
@@ -1,5 +1,6 @@
 package org.project.domain.ai.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.project.domain.ai.dto.MemoAiOptions;
@@ -7,6 +8,9 @@ import org.project.domain.ai.dto.MemoAiOptions;
 import java.util.List;
 
 public record MemoAiRequest(
+        // 대화 기록으로 저장되므로 빈 프롬프트는 허용하지 않는다.
+        // (기획: 프롬프트 입력 필드에 1글자 이상 입력 시 전송 버튼 활성화)
+        @NotBlank
         String userPrompt,
         MemoAiOptions option,
         @NotEmpty

--- a/src/main/java/org/project/domain/ai/dto/response/ActiveChatRoomResponse.java
+++ b/src/main/java/org/project/domain/ai/dto/response/ActiveChatRoomResponse.java
@@ -1,0 +1,62 @@
+package org.project.domain.ai.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(requiredProperties = {"chatRoomId", "messages"})
+public record ActiveChatRoomResponse(
+
+        @Schema(description = "활성 채팅방 ID")
+        Long chatRoomId,
+
+        @Schema(description = "대화 목록. 비어 있으면 아직 전송한 프롬프트가 없다는 의미")
+        List<ChatMessageResponse> messages
+) {
+
+    public static ActiveChatRoomResponse of(Long chatRoomId, List<ChatMessageResponse> messages) {
+        return new ActiveChatRoomResponse(chatRoomId, messages);
+    }
+
+    @Schema(requiredProperties = {"messageId", "role", "status", "memoIds", "createdAt"})
+    public record ChatMessageResponse(
+
+            Long messageId,
+
+            @Schema(description = "USER | ASSISTANT")
+            String role,
+
+            @Schema(description = "SUCCESS | FAILED. FAILED는 AI 호출이 실패한 자리로 content가 없다")
+            String status,
+
+            @Schema(description = "AI 응답의 제목. USER 메시지와 실패한 응답은 null")
+            String title,
+
+            @Schema(description = "본문. status가 FAILED면 null이며, 표시할 문구는 클라이언트가 정한다")
+            String content,
+
+            @Schema(description = "요청에 적용된 옵션. 재시도 시 그대로 사용할 수 있다")
+            MemoAiOptions option,
+
+            @Schema(description = "요청이 참조한 메모 ID 목록. 재시도 시 그대로 사용할 수 있다")
+            List<Long> memoIds,
+
+            LocalDateTime createdAt
+    ) {
+        public static ChatMessageResponse from(ChatMessage message) {
+            return new ChatMessageResponse(
+                    message.getId(),
+                    message.getRole().name(),
+                    message.getStatus().name(),
+                    message.getTitle(),
+                    message.getContent(),
+                    message.getOption(),
+                    message.getMemoIds(),
+                    message.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/org/project/domain/ai/entity/ChatMessage.java
+++ b/src/main/java/org/project/domain/ai/entity/ChatMessage.java
@@ -1,0 +1,115 @@
+package org.project.domain.ai.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.entity.converter.MemoIdsConverter;
+import org.project.global.entity.BaseEntity;
+
+import java.util.List;
+
+/**
+ * AI 채팅방의 대화 한 건.
+ * <p>
+ * spring_ai_chat_memory는 LLM에 주입할 최근 컨텍스트만 유지하므로(윈도우 초과분 물리 삭제),
+ * 화면 복원용 대화 기록은 이 엔티티에 별도로 보관한다.
+ * <p>
+ * 채팅방이 soft delete되면 조회 경로가 함께 사라지므로 별도의 isDeleted 플래그는 두지 않는다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_message")
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_message_id")
+    private Long id;
+
+    // ChatRoom(1) : ChatMessage(N)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private ChatMessageRole role;
+
+    // AI 호출이 실패한 자리(status = FAILED)에는 내용이 없다.
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ChatMessageStatus status;
+
+    // AI 응답에만 존재
+    @Column(name = "title")
+    private String title;
+
+    // 요청에 적용된 옵션. USER/ASSISTANT 모두 보관해 재시도 시 그대로 복원할 수 있다.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "option")
+    private MemoAiOptions option;
+
+    // 요청이 참조한 메모 목록. USER 메시지에도 보관해야 실패한 턴을 재시도할 수 있다.
+    @Convert(converter = MemoIdsConverter.class)
+    @Column(name = "memo_ids", columnDefinition = "TEXT")
+    private List<Long> memoIds;
+
+    /**
+     * 사용자가 보낸 질문. option/memoIds를 함께 보관하므로
+     * 이 한 건만으로 같은 요청을 재구성할 수 있다.
+     */
+    public static ChatMessage user(
+            ChatRoom chatRoom,
+            String content,
+            MemoAiOptions option,
+            List<Long> memoIds
+    ) {
+        ChatMessage message = new ChatMessage();
+        message.chatRoom = chatRoom;
+        message.role = ChatMessageRole.USER;
+        message.status = ChatMessageStatus.SUCCESS;
+        message.content = content;
+        message.option = option;
+        message.memoIds = (memoIds == null) ? List.of() : memoIds;
+        return message;
+    }
+
+    public static ChatMessage assistant(
+            ChatRoom chatRoom,
+            String title,
+            String content,
+            MemoAiOptions option,
+            List<Long> memoIds
+    ) {
+        ChatMessage message = new ChatMessage();
+        message.chatRoom = chatRoom;
+        message.role = ChatMessageRole.ASSISTANT;
+        message.status = ChatMessageStatus.SUCCESS;
+        message.title = title;
+        message.content = content;
+        message.option = option;
+        message.memoIds = (memoIds == null) ? List.of() : memoIds;
+        return message;
+    }
+
+    /**
+     * AI 호출이 실패해 응답을 받지 못한 자리.
+     * <p>
+     * 화면에 보여줄 문구는 프론트가 정하므로 content를 채우지 않는다.
+     * 재시도에 필요한 option/memoIds는 짝이 되는 USER 메시지에 있다.
+     */
+    public static ChatMessage failed(ChatRoom chatRoom) {
+        ChatMessage message = new ChatMessage();
+        message.chatRoom = chatRoom;
+        message.role = ChatMessageRole.ASSISTANT;
+        message.status = ChatMessageStatus.FAILED;
+        message.memoIds = List.of();
+        return message;
+    }
+}

--- a/src/main/java/org/project/domain/ai/entity/ChatMessageRole.java
+++ b/src/main/java/org/project/domain/ai/entity/ChatMessageRole.java
@@ -1,0 +1,6 @@
+package org.project.domain.ai.entity;
+
+public enum ChatMessageRole {
+    USER,
+    ASSISTANT
+}

--- a/src/main/java/org/project/domain/ai/entity/ChatMessageStatus.java
+++ b/src/main/java/org/project/domain/ai/entity/ChatMessageStatus.java
@@ -1,0 +1,10 @@
+package org.project.domain.ai.entity;
+
+public enum ChatMessageStatus {
+
+    /** 정상 저장된 메시지. USER 메시지는 항상 이 상태다. */
+    SUCCESS,
+
+    /** AI 호출이 실패해 응답을 받지 못한 자리. content가 없다. */
+    FAILED
+}

--- a/src/main/java/org/project/domain/ai/entity/converter/MemoIdsConverter.java
+++ b/src/main/java/org/project/domain/ai/entity/converter/MemoIdsConverter.java
@@ -1,0 +1,46 @@
+package org.project.domain.ai.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * memoIds(List&lt;Long&gt;)를 콤마로 구분된 문자열로 저장한다.
+ * <p>
+ * 조인 테이블(@ElementCollection)은 메시지 목록 조회 시 N+1을 유발하고,
+ * jsonb는 테스트 환경(H2)과 호환되지 않아 TEXT 직렬화를 사용한다.
+ */
+@Converter
+public class MemoIdsConverter implements AttributeConverter<List<Long>, String> {
+
+    private static final String DELIMITER = ",";
+
+    // 저장 시: 엔티티 필드 -> DB 컬럼
+    @Override
+    public String convertToDatabaseColumn(List<Long> memoIds) {
+        if (memoIds == null || memoIds.isEmpty()) {
+            return null;
+        }
+
+        return memoIds.stream()
+                .map(String::valueOf)
+                .reduce((a, b) -> a + DELIMITER + b)
+                .orElse(null);
+    }
+
+    // 조회 시: DB 컬럼 -> 엔티티 필드
+    @Override
+    public List<Long> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(dbData.split(DELIMITER))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Long::valueOf)
+                .toList();
+    }
+}

--- a/src/main/java/org/project/domain/ai/rag/F/augment/dto/RagPrompt.java
+++ b/src/main/java/org/project/domain/ai/rag/F/augment/dto/RagPrompt.java
@@ -1,5 +1,6 @@
 package org.project.domain.ai.rag.F.augment.dto;
 
+import org.project.domain.ai.util.ConversationIds;
 import org.project.global.exception.domainException.AiException;
 import org.project.global.exception.errorcode.AiErrorCode;
 
@@ -42,7 +43,7 @@ public record RagPrompt(
             throw new AiException(AiErrorCode.CONVERSATION_CONTEXT_NOT_SET);
         }
 
-        return "user:%d:room:%d".formatted(userId, chatRoomId);
+        return ConversationIds.of(userId, chatRoomId);
     }
 
     // systemPrompt만 교체 (Plan API 용)

--- a/src/main/java/org/project/domain/ai/repository/ChatMessageRepository.java
+++ b/src/main/java/org/project/domain/ai/repository/ChatMessageRepository.java
@@ -1,0 +1,17 @@
+package org.project.domain.ai.repository;
+
+import org.project.domain.ai.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    /**
+     * 대화 순서대로 조회한다.
+     * <p>
+     * USER/ASSISTANT 두 건을 한 트랜잭션에서 저장하면 createdAt이 동일한 값으로 기록될 수 있어
+     * 삽입 순서가 보장되는 id를 정렬 기준으로 사용한다.
+     */
+    List<ChatMessage> findByChatRoomIdOrderByIdAsc(Long chatRoomId);
+}

--- a/src/main/java/org/project/domain/ai/repository/ChatRoomRepository.java
+++ b/src/main/java/org/project/domain/ai/repository/ChatRoomRepository.java
@@ -10,6 +10,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findAllByUserIdAndIsDeletedFalse(Long userId);
 
-    Optional<ChatRoom> findTopByUserIdOrderByCreatedAtDesc(Long userId);
+    /**
+     * 활성 채팅방 조회. @Where(is_deleted = false)로 삭제된 방은 제외된다.
+     * 삭제와 생성이 한 트랜잭션에서 일어나면 createdAt이 동률로 기록될 수 있어 id를 기준으로 정렬한다.
+     */
+    Optional<ChatRoom> findTopByUserIdOrderByIdDesc(Long userId);
 }
 

--- a/src/main/java/org/project/domain/ai/service/ChatMessageService.java
+++ b/src/main/java/org/project/domain/ai/service/ChatMessageService.java
@@ -1,0 +1,23 @@
+package org.project.domain.ai.service;
+
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+
+import java.util.List;
+
+public interface ChatMessageService {
+
+    List<ActiveChatRoomResponse.ChatMessageResponse> findByChatRoomId(Long chatRoomId);
+
+    /**
+     * 사용자 프롬프트와 AI 응답을 한 번에 저장한다.
+     */
+    void saveTurn(Long chatRoomId, MemoAiRequest request, MemoAiResponse response);
+
+    /**
+     * AI 호출이 실패한 턴을 저장한다.
+     * 사용자 질문은 그대로 남기고 AI 응답 자리는 FAILED로 비워둔다.
+     */
+    void saveFailedTurn(Long chatRoomId, MemoAiRequest request);
+}

--- a/src/main/java/org/project/domain/ai/service/ChatMessageServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/ChatMessageServiceImpl.java
@@ -1,0 +1,72 @@
+package org.project.domain.ai.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.entity.ChatMessage;
+import org.project.domain.ai.entity.ChatRoom;
+import org.project.domain.ai.repository.ChatMessageRepository;
+import org.project.domain.ai.repository.ChatRoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageServiceImpl implements ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public List<ActiveChatRoomResponse.ChatMessageResponse> findByChatRoomId(Long chatRoomId) {
+        return chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoomId)
+                .stream()
+                .map(ActiveChatRoomResponse.ChatMessageResponse::from)
+                .toList();
+    }
+
+    /**
+     * RAG 호출은 수 초가 걸리므로 트랜잭션 밖에서 수행하고,
+     * 저장만 이 짧은 쓰기 트랜잭션으로 분리한다.
+     */
+    @Override
+    @Transactional
+    public void saveTurn(Long chatRoomId, MemoAiRequest request, MemoAiResponse response) {
+        ChatRoom chatRoom = chatRoomRepository.getReferenceById(chatRoomId);
+
+        chatMessageRepository.save(saveUser(chatRoom, request));
+        chatMessageRepository.save(ChatMessage.assistant(
+                chatRoom,
+                response.title(),
+                response.content(),
+                response.option(),
+                response.memoIds()
+        ));
+    }
+
+    /**
+     * 실패한 턴도 대화에 남긴다. 사용자가 나중에 스크롤을 올려
+     * 무엇을 요청했다가 실패했는지 확인하고 그대로 재시도할 수 있어야 한다.
+     */
+    @Override
+    @Transactional
+    public void saveFailedTurn(Long chatRoomId, MemoAiRequest request) {
+        ChatRoom chatRoom = chatRoomRepository.getReferenceById(chatRoomId);
+
+        chatMessageRepository.save(saveUser(chatRoom, request));
+        chatMessageRepository.save(ChatMessage.failed(chatRoom));
+    }
+
+    private ChatMessage saveUser(ChatRoom chatRoom, MemoAiRequest request) {
+        return ChatMessage.user(
+                chatRoom,
+                request.userPrompt(),
+                request.option(),
+                request.memoIds()
+        );
+    }
+}

--- a/src/main/java/org/project/domain/ai/service/ChatRoomService.java
+++ b/src/main/java/org/project/domain/ai/service/ChatRoomService.java
@@ -1,9 +1,12 @@
 package org.project.domain.ai.service;
 
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
 import org.project.domain.ai.dto.response.ChatRoomListResponse;
 import org.project.domain.ai.entity.ChatRoom;
 
 public interface ChatRoomService {
+
+    ActiveChatRoomResponse getActiveConversation(Long userId);
 
     ChatRoom create(Long userId);
 

--- a/src/main/java/org/project/domain/ai/service/ChatRoomServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/ChatRoomServiceImpl.java
@@ -103,6 +103,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     /**
      * 공통 검증 메서드
+     * <p>
+     * ChatRoom의 @Where(is_deleted = false)로 삭제된 채팅방은 조회되지 않으므로,
+     * 삭제된 채팅방에 접근하면 CHAT_ROOM_NOT_FOUND로 응답한다.
      */
     @Override
     public ChatRoom validateAccess(Long userId, Long chatRoomId) {
@@ -114,10 +117,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         if (!chatRoom.getUser().getId().equals(userId)) {
             throw new ChatRoomException(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED);
-        }
-
-        if (Boolean.TRUE.equals(chatRoom.getIsDeleted())) {
-            throw new ChatRoomException(ChatRoomErrorCode.CHAT_ROOM_ALREADY_DELETED);
         }
 
         return chatRoom;

--- a/src/main/java/org/project/domain/ai/service/ChatRoomServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/ChatRoomServiceImpl.java
@@ -1,15 +1,21 @@
 package org.project.domain.ai.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
 import org.project.domain.ai.dto.response.ChatRoomListResponse;
 import org.project.domain.ai.entity.ChatRoom;
 import org.project.domain.ai.repository.ChatRoomRepository;
+import org.project.domain.ai.util.ConversationIds;
 import org.project.domain.user.entity.User;
 import org.project.domain.user.repository.UserRepository;
 import org.project.global.exception.domainException.ChatRoomException;
 import org.project.global.exception.errorcode.ChatRoomErrorCode;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,19 +24,46 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
+    private final ChatMessageService chatMessageService;
+    private final ChatMemory chatMemory;
 
+    /**
+     * AI 패널 진입용. 활성 채팅방과 대화 목록을 함께 반환한다.
+     */
+    @Override
+    @Transactional
+    public ActiveChatRoomResponse getActiveConversation(Long userId) {
+
+        Optional<ChatRoom> activeChatRoom = findActiveChatRoom(userId);
+
+        if (activeChatRoom.isEmpty()) {
+            ChatRoom created = save(userId);
+            return ActiveChatRoomResponse.of(created.getId(), List.of());
+        }
+
+        Long chatRoomId = activeChatRoom.get().getId();
+
+        return ActiveChatRoomResponse.of(
+                chatRoomId,
+                chatMessageService.findByChatRoomId(chatRoomId)
+        );
+    }
+
+    /**
+     * 새 대화 시작. 기존 활성 채팅방과 대화 컨텍스트를 정리한 뒤 새 채팅방을 만든다.
+     */
+    @Override
     @Transactional
     public ChatRoom create(Long userId) {
-        User user = userRepository.getReferenceById(userId);
 
-        ChatRoom chatRoom = ChatRoom.builder()
-                .user(user)
-                .build();
+        findActiveChatRoom(userId)
+                .ifPresent(previous -> clearConversation(userId, previous));
 
-        return chatRoomRepository.save(chatRoom);
+        return save(userId);
     }
 
 
+    @Override
     public ChatRoomListResponse findAllByUser(Long userId) {
         return ChatRoomListResponse.of(
                 chatRoomRepository.findAllByUserIdAndIsDeletedFalse(userId)
@@ -49,8 +82,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     @Override
     public ChatRoomListResponse.ChatRoomResponse findLatestChatRoomByUser(Long userId) {
 
-        ChatRoom chatRoom = chatRoomRepository
-                .findTopByUserIdOrderByCreatedAtDesc(userId)
+        ChatRoom chatRoom = findActiveChatRoom(userId)
                 .orElseThrow(() -> new ChatRoomException(
                         ChatRoomErrorCode.CHAT_ROOM_NOT_FOUND
                 ));
@@ -59,21 +91,20 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
 
+    @Override
     @Transactional
     public void delete(Long userId, Long chatRoomId) {
 
         ChatRoom chatRoom = validateAccess(userId, chatRoomId);
 
-        chatRoom.markDeleted(); // isDeleted = true
+        clearConversation(userId, chatRoom);
     }
 
 
     /**
      * 공통 검증 메서드
-     * @param userId
-     * @param chatRoomId
-     * @return
      */
+    @Override
     public ChatRoom validateAccess(Long userId, Long chatRoomId) {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -90,5 +121,35 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         }
 
         return chatRoom;
+    }
+
+
+    /**
+     * 채팅방은 soft delete하고, Spring AI가 관리하는 대화 컨텍스트는 물리 삭제한다.
+     * (ChatMemory는 clear() 외에 삭제 수단을 제공하지 않는다)
+     */
+    private void clearConversation(Long userId, ChatRoom chatRoom) {
+        chatRoom.markDeleted();
+        chatMemory.clear(ConversationIds.of(userId, chatRoom.getId()));
+    }
+
+
+    /**
+     * 활성 채팅방 조회. ChatRoom의 @Where(is_deleted = false)로 삭제된 방은 제외된다.
+     * 삭제와 생성이 한 트랜잭션에서 일어나면 createdAt이 동률로 기록될 수 있어 id를 기준으로 정렬한다.
+     */
+    private Optional<ChatRoom> findActiveChatRoom(Long userId) {
+        return chatRoomRepository.findTopByUserIdOrderByIdDesc(userId);
+    }
+
+
+    private ChatRoom save(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        return chatRoomRepository.save(
+                ChatRoom.builder()
+                        .user(user)
+                        .build()
+        );
     }
 }

--- a/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
+++ b/src/main/java/org/project/domain/ai/service/MemoAiServiceImpl.java
@@ -1,6 +1,7 @@
 package org.project.domain.ai.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.domain.ai.dto.request.MemoAiRequest;
 import org.project.domain.ai.dto.request.MemoAiRequestForPlan;
 import org.project.domain.ai.dto.response.AiEvaluationResult;
@@ -10,12 +11,14 @@ import org.project.domain.ai.rag.pipeline.RagPipeline;
 import org.project.global.exception.InsufficientRagContextException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemoAiServiceImpl implements MemoAiService {
 
     private final RagPipeline ragPipeline;
     private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
 
     private final AiEvaluationService aiEvaluationService;
 
@@ -29,9 +32,11 @@ public class MemoAiServiceImpl implements MemoAiService {
         // 접근 검증
         chatRoomService.validateAccess(userId, chatRoomId);
 
+        MemoAiResponse response;
+
         try {
             // 정상 RAG 파이프라인 실행
-            return ragPipeline.run(
+            response = ragPipeline.run(
                     userId,
                     chatRoomId,
                     request
@@ -39,12 +44,36 @@ public class MemoAiServiceImpl implements MemoAiService {
 
         } catch (InsufficientRagContextException e) {
 
-            return MemoAiResponse.of(
+            response = MemoAiResponse.of(
                     /* title */ "AI 응답을 생성할 수 없습니다",
                     /* content */ e.getMessage(),
                     /* option */ request.option(),
                     /* memoIds */ request.memoIds(),
                     /* debug */ null   // or "CONTEXT_TOO_SHORT"
+            );
+
+        } catch (Exception e) {
+            // AI 호출 실패도 대화에 남긴다. 저장이 실패하더라도
+            // 클라이언트에는 원래 AI 예외가 전달되어야 한다.
+            saveFailedTurnQuietly(chatRoomId, request);
+            throw e;
+        }
+
+        // 컨텍스트 부족 안내도 화면에는 AI 응답으로 노출되므로 함께 저장한다.
+        // RAG 호출이 끝난 뒤 호출되므로 저장만 짧은 트랜잭션으로 처리된다.
+        chatMessageService.saveTurn(chatRoomId, request, response);
+
+        return response;
+    }
+
+    private void saveFailedTurnQuietly(Long chatRoomId, MemoAiRequest request) {
+        try {
+            chatMessageService.saveFailedTurn(chatRoomId, request);
+        } catch (Exception saveError) {
+            log.error(
+                    "실패한 턴 저장에 실패 [chatRoomId={}]",
+                    chatRoomId,
+                    saveError
             );
         }
     }

--- a/src/main/java/org/project/domain/ai/util/ConversationIds.java
+++ b/src/main/java/org/project/domain/ai/util/ConversationIds.java
@@ -1,0 +1,16 @@
+package org.project.domain.ai.util;
+
+/**
+ * Spring AI ChatMemory의 conversationId 규칙을 한곳에서 관리한다.
+ */
+public final class ConversationIds {
+
+    private static final String FORMAT = "user:%d:room:%d";
+
+    private ConversationIds() {
+    }
+
+    public static String of(Long userId, Long chatRoomId) {
+        return FORMAT.formatted(userId, chatRoomId);
+    }
+}

--- a/src/main/java/org/project/global/config/ai/AiConfig.java
+++ b/src/main/java/org/project/global/config/ai/AiConfig.java
@@ -22,10 +22,13 @@ public class AiConfig {
     }
 
     @Bean
-    public ChatMemory chatMemory(JdbcChatMemoryRepository repository) {
+    public ChatMemory chatMemory(
+            JdbcChatMemoryRepository repository,
+            ChatMemoryProperties properties
+    ) {
         return MessageWindowChatMemory.builder()
                 .chatMemoryRepository(repository)
-                .maxMessages(10)
+                .maxMessages(properties.getMaxMessages())
                 .build();
     }
 }

--- a/src/main/java/org/project/global/config/ai/ChatMemoryProperties.java
+++ b/src/main/java/org/project/global/config/ai/ChatMemoryProperties.java
@@ -1,0 +1,27 @@
+package org.project.global.config.ai;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@Configuration
+@ConfigurationProperties(prefix = "ai.chat-memory")
+public class ChatMemoryProperties {
+
+    /**
+     * LLM 프롬프트에 함께 실어 보낼 최근 메시지 수.
+     * <p>
+     * 초과분은 spring_ai_chat_memory에서 물리 삭제되므로 AI가 기억하는 범위를 결정한다.
+     * 화면에 복원되는 대화(chat_message)는 전체가 남으므로, 이 값이 작을수록
+     * "화면에는 보이지만 AI는 기억하지 못하는" 구간이 넓어진다.
+     * 토큰 비용과 Gemini 쿼터를 고려해 조정한다.
+     */
+    @Min(2)
+    private int maxMessages;
+}

--- a/src/main/java/org/project/global/exception/errorcode/AiErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/AiErrorCode.java
@@ -12,10 +12,11 @@ public enum AiErrorCode implements ErrorCode {
     EMPTY_MEMO_IDS(HttpStatus.BAD_REQUEST, 400, "참조할 메모가 선택되지 않았습니다."),
     CONVERSATION_CONTEXT_NOT_SET(HttpStatus.BAD_REQUEST, 400, "conversation context is not set (userId / chatRoomId)"),
     AI_GENERATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요."),
-    AI_RESPONSE_NULL(HttpStatus.BAD_REQUEST, 400, "AI 응답이 null 입니다."),
-    AI_RESPONSE_EMPTY(HttpStatus.BAD_REQUEST, 400, "AI 응답이 비어 있습니다."),
-    AI_TITLE_EXTRACTION_FAILED(HttpStatus.BAD_REQUEST, 400, "AI 응답에서 제목을 추출할 수 없습니다."),
-    AI_TITLE_EMPTY(HttpStatus.BAD_REQUEST, 400, "AI 응답의 제목이 비어 있습니다."),;
+    // 아래 네 가지는 모두 AI가 약속된 응답 형식(1행 제목 / 2행부터 본문)을 지키지 않은 경우다.
+    AI_RESPONSE_EMPTY(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI 응답을 처리하지 못했습니다. 잠시 후 다시 시도해주세요."),
+    AI_RESPONSE_NULL(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI 응답을 처리하지 못했습니다. 잠시 후 다시 시도해주세요."),
+    AI_TITLE_EXTRACTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI 응답을 처리하지 못했습니다. 잠시 후 다시 시도해주세요."),
+    AI_TITLE_EMPTY(HttpStatus.SERVICE_UNAVAILABLE, 503, "AI 응답을 처리하지 못했습니다. 잠시 후 다시 시도해주세요."),;
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/org/project/global/exception/errorcode/ChatRoomErrorCode.java
+++ b/src/main/java/org/project/global/exception/errorcode/ChatRoomErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ChatRoomErrorCode implements ErrorCode {
 
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "채팅방이 존재하지 않습니다."),
-    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "채팅방에 대한 권한이 없습니다."),
-    CHAT_ROOM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 400, "이미 삭제된 채팅방입니다.");
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "채팅방에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/org/project/global/util/MemoContentParser.java
+++ b/src/main/java/org/project/global/util/MemoContentParser.java
@@ -18,12 +18,9 @@ public final class MemoContentParser {
             throw new AiException(AiErrorCode.AI_RESPONSE_EMPTY);
         }
 
+        // 본문 없이 한 줄만 온 경우. 약속된 형식(1행 제목 / 2행부터 본문)을 지키지 않은 응답이다.
         int firstNewline = normalized.indexOf('\n');
         if (firstNewline < 0) {
-            String title = normalized.trim();
-            if (title.isEmpty()) {
-                title = "AI Memo";
-            }
             throw new AiException(AiErrorCode.AI_TITLE_EXTRACTION_FAILED);
         }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -146,3 +146,7 @@ swagger:
   auth:
     username: ${SWAGGER_USERNAME}
     password: ${SWAGGER_PASSWORD}
+
+ai:
+  chat-memory:
+    max-messages: 10

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -146,3 +146,7 @@ logging:
   level:
     org.hibernate.stat: DEBUG
     org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: DEBUG
+
+ai:
+  chat-memory:
+    max-messages: 10

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -142,3 +142,7 @@ logging:
     org.springframework.ai: INFO
     org.springframework.web.client: WARN
     org.springframework.web.reactive.function.client: WARN
+
+ai:
+  chat-memory:
+    max-messages: 10

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -101,3 +101,7 @@ cloud:
   aws:
     s3:
       bucket: test-bucket
+
+ai:
+  chat-memory:
+    max-messages: 10

--- a/src/test/java/org/project/domain/ai/controller/ChatRoomControllerTest.java
+++ b/src/test/java/org/project/domain/ai/controller/ChatRoomControllerTest.java
@@ -1,0 +1,140 @@
+package org.project.domain.ai.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.service.ChatRoomService;
+import org.project.domain.user.dto.CustomUserDetails;
+import org.project.domain.user.entity.User;
+import org.project.global.security.filter.JWTFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatRoomController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("ChatRoomController 테스트")
+class ChatRoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatRoomService chatRoomService;
+
+    @MockBean
+    private JWTFilter jwtFilter;
+
+    @Test
+    @DisplayName("대화가 없는 채팅방은 빈 messages 배열을 반환한다")
+    @WithMockCustomUser
+    void getActiveConversation_emptyRoom() throws Exception {
+        // given
+        when(chatRoomService.getActiveConversation(1L))
+                .thenReturn(ActiveChatRoomResponse.of(7L, List.of()));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/chat-rooms/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.chatRoomId").value(7L))
+                .andExpect(jsonPath("$.data.messages").isEmpty());
+    }
+
+    @Test
+    @DisplayName("대화가 있는 채팅방은 사용자 프롬프트와 AI 답변을 순서대로 반환한다")
+    @WithMockCustomUser
+    void getActiveConversation_withMessages() throws Exception {
+        // given
+        when(chatRoomService.getActiveConversation(1L)).thenReturn(
+                ActiveChatRoomResponse.of(7L, List.of(
+                        new ActiveChatRoomResponse.ChatMessageResponse(
+                                1L, "USER", "SUCCESS", null, "이 메모들 정리해줘",
+                                MemoAiOptions.MERGE, List.of(11L, 12L), LocalDateTime.now()),
+                        new ActiveChatRoomResponse.ChatMessageResponse(
+                                2L, "ASSISTANT", "SUCCESS", "주간 회의 정리", "본문",
+                                MemoAiOptions.MERGE, List.of(11L, 12L), LocalDateTime.now())
+                ))
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/chat-rooms/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messages.length()").value(2))
+                .andExpect(jsonPath("$.data.messages[0].role").value("USER"))
+                .andExpect(jsonPath("$.data.messages[1].role").value("ASSISTANT"))
+                .andExpect(jsonPath("$.data.messages[1].title").value("주간 회의 정리"))
+                .andExpect(jsonPath("$.data.messages[1].option").value("MERGE"))
+                .andExpect(jsonPath("$.data.messages[1].memoIds[0]").value(11L));
+    }
+
+    @Test
+    @DisplayName("AI 호출이 실패한 턴은 FAILED 상태로, 재시도에 필요한 요청 정보와 함께 반환된다")
+    @WithMockCustomUser
+    void getActiveConversation_failedTurn() throws Exception {
+        // given
+        when(chatRoomService.getActiveConversation(1L)).thenReturn(
+                ActiveChatRoomResponse.of(7L, List.of(
+                        new ActiveChatRoomResponse.ChatMessageResponse(
+                                3L, "USER", "SUCCESS", null, "정리해줘",
+                                MemoAiOptions.STRUCTURE, List.of(11L, 12L), LocalDateTime.now()),
+                        new ActiveChatRoomResponse.ChatMessageResponse(
+                                4L, "ASSISTANT", "FAILED", null, null,
+                                null, List.of(), LocalDateTime.now())
+                ))
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/chat-rooms/active"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messages[0].option").value("STRUCTURE"))
+                .andExpect(jsonPath("$.data.messages[0].memoIds[0]").value(11L))
+                .andExpect(jsonPath("$.data.messages[1].status").value("FAILED"))
+                .andExpect(jsonPath("$.data.messages[1].content").doesNotExist());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+    @interface WithMockCustomUser {
+        long userId() default 1L;
+    }
+
+    static class WithMockCustomUserSecurityContextFactory
+            implements WithSecurityContextFactory<WithMockCustomUser> {
+        @Override
+        public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+            User user = User.builder()
+                    .id(annotation.userId())
+                    .email("test@example.com")
+                    .name("테스트유저")
+                    .providerName("google")
+                    .profileImageUrl(null)
+                    .build();
+
+            CustomUserDetails userDetails = new CustomUserDetails(user);
+            context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+            ));
+            return context;
+        }
+    }
+}

--- a/src/test/java/org/project/domain/ai/controller/ChatRoomControllerTest.java
+++ b/src/test/java/org/project/domain/ai/controller/ChatRoomControllerTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.project.domain.ai.dto.MemoAiOptions;
 import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.dto.response.ChatRoomListResponse;
+import org.project.domain.ai.entity.ChatRoom;
 import org.project.domain.ai.service.ChatRoomService;
+import org.project.global.exception.domainException.ChatRoomException;
+import org.project.global.exception.errorcode.ChatRoomErrorCode;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.project.domain.user.dto.CustomUserDetails;
 import org.project.domain.user.entity.User;
 import org.project.global.security.filter.JWTFilter;
@@ -24,8 +29,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -108,6 +118,79 @@ class ChatRoomControllerTest {
                 .andExpect(jsonPath("$.data.messages[0].memoIds[0]").value(11L))
                 .andExpect(jsonPath("$.data.messages[1].status").value("FAILED"))
                 .andExpect(jsonPath("$.data.messages[1].content").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("새 대화를 시작하면 생성된 채팅방 ID를 반환한다")
+    @WithMockCustomUser
+    void createChatRoom_returnsNewChatRoomId() throws Exception {
+        // given
+        ChatRoom created = ChatRoom.builder().build();
+        ReflectionTestUtils.setField(created, "id", 8L);
+        when(chatRoomService.create(1L)).thenReturn(created);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/chat-rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.chatRoomId").value(8L));
+    }
+
+    @Test
+    @DisplayName("채팅방 목록을 반환한다")
+    @WithMockCustomUser
+    void getChatRooms_returnsList() throws Exception {
+        // given
+        when(chatRoomService.findAllByUser(1L)).thenReturn(
+                ChatRoomListResponse.of(List.of(
+                        ChatRoomListResponse.ChatRoomResponse.of(7L, LocalDateTime.now()),
+                        ChatRoomListResponse.ChatRoomResponse.of(8L, LocalDateTime.now())
+                ))
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/chat-rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.chatRooms.length()").value(2))
+                .andExpect(jsonPath("$.data.chatRooms[0].chatRoomId").value(7L));
+    }
+
+    @Test
+    @DisplayName("최근 채팅방이 없으면 404를 반환한다")
+    @WithMockCustomUser
+    void findLatestChatRoom_notFound() throws Exception {
+        // given
+        when(chatRoomService.findLatestChatRoomByUser(1L))
+                .thenThrow(new ChatRoomException(ChatRoomErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/chat-rooms/latest"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404));
+    }
+
+    @Test
+    @DisplayName("채팅방을 삭제한다")
+    @WithMockCustomUser
+    void deleteChatRoom_success() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/chat-rooms/7"))
+                .andExpect(status().isOk());
+
+        verify(chatRoomService).delete(1L, 7L);
+    }
+
+    @Test
+    @DisplayName("남의 채팅방을 삭제하면 403을 반환한다")
+    @WithMockCustomUser
+    void deleteChatRoom_accessDenied() throws Exception {
+        // given
+        doThrow(new ChatRoomException(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED))
+                .when(chatRoomService).delete(anyLong(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/chat-rooms/7"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403));
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/org/project/domain/ai/controller/MemoAiControllerTest.java
+++ b/src/test/java/org/project/domain/ai/controller/MemoAiControllerTest.java
@@ -1,0 +1,123 @@
+package org.project.domain.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.service.MemoAiService;
+import org.project.domain.user.dto.CustomUserDetails;
+import org.project.domain.user.entity.User;
+import org.project.global.security.filter.JWTFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemoAiController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemoAiController 테스트")
+class MemoAiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemoAiService memoAiService;
+
+    @MockBean
+    private org.project.domain.ai.rag.pipeline.RagPipeline ragPipeline;
+
+    @MockBean
+    private org.project.domain.ai.service.AiEvaluationService aiEvaluationService;
+
+    @MockBean
+    private org.project.domain.ai.service.ChatRoomService chatRoomService;
+
+    @MockBean
+    private org.project.domain.ai.service.DummyService dummyService;
+
+    @MockBean
+    private JWTFilter jwtFilter;
+
+    @Test
+    @DisplayName("userPrompt가 비어 있으면 400을 반환하고 AI 호출로 넘어가지 않는다")
+    @WithMockCustomUser
+    void generateMemoAi_blankUserPrompt_returnsBadRequest() throws Exception {
+        // given
+        MemoAiRequest request = MemoAiRequest.of("   ", MemoAiOptions.MERGE, List.of(11L));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/chat-rooms/7/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(memoAiService, never()).generate(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("userPrompt가 null이면 400을 반환하고 AI 호출로 넘어가지 않는다")
+    @WithMockCustomUser
+    void generateMemoAi_nullUserPrompt_returnsBadRequest() throws Exception {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(null, MemoAiOptions.MERGE, List.of(11L));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/chat-rooms/7/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(memoAiService, never()).generate(anyLong(), anyLong(), any());
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+    @interface WithMockCustomUser {
+        long userId() default 1L;
+    }
+
+    static class WithMockCustomUserSecurityContextFactory
+            implements WithSecurityContextFactory<WithMockCustomUser> {
+        @Override
+        public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+            User user = User.builder()
+                    .id(annotation.userId())
+                    .email("test@example.com")
+                    .name("테스트유저")
+                    .providerName("google")
+                    .profileImageUrl(null)
+                    .build();
+
+            CustomUserDetails userDetails = new CustomUserDetails(user);
+            context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+            ));
+            return context;
+        }
+    }
+}

--- a/src/test/java/org/project/domain/ai/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/org/project/domain/ai/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,160 @@
+package org.project.domain.ai.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.entity.ChatMessage;
+import org.project.domain.ai.entity.ChatMessageRole;
+import org.project.domain.ai.entity.ChatMessageStatus;
+import org.project.domain.ai.entity.ChatRoom;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.querydsl.QuerydslTestConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("ChatMessageRepository 테스트")
+class ChatMessageRepositoryTest {
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("같은 트랜잭션에서 저장한 메시지도 id 오름차순으로 조회된다")
+    void findByChatRoomIdOrderByIdAsc_sameTransaction_keepsInsertOrder() {
+        // given
+        ChatRoom chatRoom = createChatRoom();
+
+        chatMessageRepository.save(ChatMessage.user(
+                chatRoom, "이 메모들 정리해줘", MemoAiOptions.MERGE, List.of(11L, 12L)));
+        chatMessageRepository.save(ChatMessage.assistant(
+                chatRoom, "주간 회의 정리", "정리된 본문",
+                MemoAiOptions.MERGE, List.of(11L, 12L, 13L)
+        ));
+        em.flush();
+        em.clear();
+
+        // when
+        List<ChatMessage> messages =
+                chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoom.getId());
+
+        // then
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getRole()).isEqualTo(ChatMessageRole.USER);
+        assertThat(messages.get(1).getRole()).isEqualTo(ChatMessageRole.ASSISTANT);
+    }
+
+    @Test
+    @DisplayName("ASSISTANT 메시지의 memoIds는 저장 후 그대로 복원된다")
+    void memoIds_roundTrip() {
+        // given
+        ChatRoom chatRoom = createChatRoom();
+        chatMessageRepository.save(ChatMessage.assistant(
+                chatRoom, "제목", "본문", MemoAiOptions.SUMMARY, List.of(11L, 12L, 13L)
+        ));
+        em.flush();
+        em.clear();
+
+        // when
+        ChatMessage found =
+                chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoom.getId()).get(0);
+
+        // then
+        assertThat(found.getMemoIds()).containsExactly(11L, 12L, 13L);
+        assertThat(found.getOption()).isEqualTo(MemoAiOptions.SUMMARY);
+        assertThat(found.getTitle()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("USER 메시지는 재시도에 필요한 option과 memoIds를 함께 보관한다")
+    void userMessage_keepsRequestContext() {
+        // given
+        ChatRoom chatRoom = createChatRoom();
+        chatMessageRepository.save(ChatMessage.user(
+                chatRoom, "정리해줘", MemoAiOptions.STRUCTURE, List.of(11L, 12L)));
+        em.flush();
+        em.clear();
+
+        // when
+        ChatMessage found =
+                chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoom.getId()).get(0);
+
+        // then
+        assertThat(found.getOption()).isEqualTo(MemoAiOptions.STRUCTURE);
+        assertThat(found.getMemoIds()).containsExactly(11L, 12L);
+        assertThat(found.getStatus()).isEqualTo(ChatMessageStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("실패한 AI 응답은 content 없이 FAILED 상태로 저장된다")
+    void failedAssistantMessage_hasNoContent() {
+        // given
+        ChatRoom chatRoom = createChatRoom();
+        chatMessageRepository.save(ChatMessage.failed(chatRoom));
+        em.flush();
+        em.clear();
+
+        // when
+        ChatMessage found =
+                chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoom.getId()).get(0);
+
+        // then
+        assertThat(found.getRole()).isEqualTo(ChatMessageRole.ASSISTANT);
+        assertThat(found.getStatus()).isEqualTo(ChatMessageStatus.FAILED);
+        assertThat(found.getContent()).isNull();
+        assertThat(found.getTitle()).isNull();
+    }
+
+    @Test
+    @DisplayName("USER 메시지는 title 없이 저장된다")
+    void userMessage_hasNoAssistantFields() {
+        // given
+        ChatRoom chatRoom = createChatRoom();
+        chatMessageRepository.save(ChatMessage.user(
+                chatRoom, "질문", MemoAiOptions.MERGE, List.of(11L)));
+        em.flush();
+        em.clear();
+
+        // when
+        ChatMessage found =
+                chatMessageRepository.findByChatRoomIdOrderByIdAsc(chatRoom.getId()).get(0);
+
+        // then
+        assertThat(found.getContent()).isEqualTo("질문");
+        assertThat(found.getTitle()).isNull();
+    }
+
+    private ChatRoom createChatRoom() {
+        User user = userRepository.save(createUser());
+        return chatRoomRepository.save(ChatRoom.builder().user(user).build());
+    }
+
+    private User createUser() {
+        return User.createSocialUser(
+                "test" + UUID.randomUUID() + "@test.com",
+                "테스트 유저",
+                "profile.png",
+                "google"
+        );
+    }
+}

--- a/src/test/java/org/project/domain/ai/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/org/project/domain/ai/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,86 @@
+package org.project.domain.ai.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.ai.entity.ChatRoom;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.querydsl.QuerydslTestConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslTestConfig.class)
+@DisplayName("ChatRoomRepository 테스트")
+class ChatRoomRepositoryTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    /**
+     * ChatRoom의 @Where(is_deleted = false) 때문에 삭제된 채팅방은 조회 자체가 되지 않는다.
+     * 그래서 validateAccess는 삭제된 방에 대해 "이미 삭제됨"이 아니라 "존재하지 않음"으로 응답한다.
+     * 이 동작이 깨지면 삭제된 방의 접근 응답이 바뀌므로 여기서 고정해 둔다.
+     */
+    @Test
+    @DisplayName("soft delete된 채팅방은 findById로 조회되지 않는다")
+    void findById_softDeleted_returnsEmpty() {
+        // given
+        ChatRoom chatRoom = chatRoomRepository.save(
+                ChatRoom.builder().user(userRepository.save(createUser())).build()
+        );
+        Long chatRoomId = chatRoom.getId();
+
+        chatRoom.markDeleted();
+        em.flush();
+        em.clear();
+
+        // when & then
+        assertThat(chatRoomRepository.findById(chatRoomId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("활성 채팅방 조회는 삭제된 방을 건너뛰고 가장 최근 방을 반환한다")
+    void findTopByUserIdOrderByIdDesc_skipsDeleted() {
+        // given
+        User user = userRepository.save(createUser());
+
+        ChatRoom older = chatRoomRepository.save(ChatRoom.builder().user(user).build());
+        ChatRoom latest = chatRoomRepository.save(ChatRoom.builder().user(user).build());
+
+        latest.markDeleted();
+        em.flush();
+        em.clear();
+
+        // when
+        ChatRoom active = chatRoomRepository
+                .findTopByUserIdOrderByIdDesc(user.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(active.getId()).isEqualTo(older.getId());
+    }
+
+    private User createUser() {
+        return User.createSocialUser(
+                "test" + UUID.randomUUID() + "@test.com",
+                "테스트 유저",
+                "profile.png",
+                "google"
+        );
+    }
+}

--- a/src/test/java/org/project/domain/ai/service/ChatMessageServiceImplTest.java
+++ b/src/test/java/org/project/domain/ai/service/ChatMessageServiceImplTest.java
@@ -1,0 +1,265 @@
+package org.project.domain.ai.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.entity.ChatRoom;
+import org.project.domain.ai.repository.ChatMessageRepository;
+import org.project.domain.ai.repository.ChatRoomRepository;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.querydsl.QuerydslTestConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 저장이 본업인 서비스라 목이 아닌 실제 영속화 결과로 검증한다.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({QuerydslTestConfig.class, ChatMessageServiceImpl.class})
+@DisplayName("ChatMessageService 테스트")
+class ChatMessageServiceImplTest {
+
+    @Autowired
+    private ChatMessageServiceImpl chatMessageService;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Nested
+    @DisplayName("saveTurn")
+    class SaveTurn {
+
+        @Test
+        @DisplayName("사용자 질문과 AI 응답을 순서대로 두 건 저장한다")
+        void savesUserAndAssistantInOrder() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+            MemoAiRequest request = MemoAiRequest.of(
+                    "이 메모들 정리해줘", MemoAiOptions.MERGE, List.of(11L, 12L));
+            MemoAiResponse response = MemoAiResponse.of(
+                    "주간 회의 정리", "정리된 본문", MemoAiOptions.MERGE, List.of(11L, 12L), null);
+
+            // when
+            chatMessageService.saveTurn(chatRoomId, request, response);
+            flushAndClear();
+
+            // then
+            List<ActiveChatRoomResponse.ChatMessageResponse> messages =
+                    chatMessageService.findByChatRoomId(chatRoomId);
+
+            assertThat(messages).hasSize(2);
+            assertThat(messages.get(0).role()).isEqualTo("USER");
+            assertThat(messages.get(0).content()).isEqualTo("이 메모들 정리해줘");
+            assertThat(messages.get(1).role()).isEqualTo("ASSISTANT");
+            assertThat(messages.get(1).title()).isEqualTo("주간 회의 정리");
+            assertThat(messages.get(1).content()).isEqualTo("정리된 본문");
+        }
+
+        @Test
+        @DisplayName("사용자 메시지에도 재시도에 필요한 option과 memoIds를 보관한다")
+        void userMessageKeepsRequestContext() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+
+            // when
+            chatMessageService.saveTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("구조화해줘", MemoAiOptions.STRUCTURE, List.of(21L, 22L)),
+                    MemoAiResponse.of("제목", "본문", MemoAiOptions.STRUCTURE, List.of(21L, 22L), null)
+            );
+            flushAndClear();
+
+            // then
+            var userMessage = chatMessageService.findByChatRoomId(chatRoomId).get(0);
+            assertThat(userMessage.option()).isEqualTo(MemoAiOptions.STRUCTURE);
+            assertThat(userMessage.memoIds()).containsExactly(21L, 22L);
+        }
+
+        @Test
+        @DisplayName("두 건 모두 SUCCESS 상태로 저장된다")
+        void bothMessagesAreSuccess() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+
+            // when
+            chatMessageService.saveTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("정리해줘", MemoAiOptions.MERGE, List.of(11L)),
+                    MemoAiResponse.of("제목", "본문", MemoAiOptions.MERGE, List.of(11L), null)
+            );
+            flushAndClear();
+
+            // then
+            assertThat(chatMessageService.findByChatRoomId(chatRoomId))
+                    .extracting(ActiveChatRoomResponse.ChatMessageResponse::status)
+                    .containsExactly("SUCCESS", "SUCCESS");
+        }
+    }
+
+    @Nested
+    @DisplayName("saveFailedTurn")
+    class SaveFailedTurn {
+
+        @Test
+        @DisplayName("사용자 질문은 남기고 AI 응답 자리는 FAILED로 비워 둔다")
+        void keepsUserPromptAndMarksAssistantFailed() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+
+            // when
+            chatMessageService.saveFailedTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("정리해줘", MemoAiOptions.SUMMARY, List.of(31L, 32L))
+            );
+            flushAndClear();
+
+            // then
+            List<ActiveChatRoomResponse.ChatMessageResponse> messages =
+                    chatMessageService.findByChatRoomId(chatRoomId);
+
+            assertThat(messages).hasSize(2);
+
+            var userMessage = messages.get(0);
+            assertThat(userMessage.status()).isEqualTo("SUCCESS");
+            assertThat(userMessage.content()).isEqualTo("정리해줘");
+
+            var failedMessage = messages.get(1);
+            assertThat(failedMessage.role()).isEqualTo("ASSISTANT");
+            assertThat(failedMessage.status()).isEqualTo("FAILED");
+            assertThat(failedMessage.content()).isNull();
+            assertThat(failedMessage.title()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패해도 재시도할 수 있도록 사용자 메시지에 요청 정보를 남긴다")
+        void failedTurnKeepsRetryContext() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+
+            // when
+            chatMessageService.saveFailedTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("정리해줘", MemoAiOptions.SUMMARY, List.of(31L, 32L))
+            );
+            flushAndClear();
+
+            // then
+            var userMessage = chatMessageService.findByChatRoomId(chatRoomId).get(0);
+            assertThat(userMessage.option()).isEqualTo(MemoAiOptions.SUMMARY);
+            assertThat(userMessage.memoIds()).containsExactly(31L, 32L);
+        }
+
+        @Test
+        @DisplayName("실패한 턴이 반복되면 그대로 누적된다")
+        void repeatedFailuresAccumulate() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+            MemoAiRequest request = MemoAiRequest.of("정리해줘", MemoAiOptions.MERGE, List.of(41L));
+
+            // when
+            chatMessageService.saveFailedTurn(chatRoomId, request);
+            chatMessageService.saveFailedTurn(chatRoomId, request);
+            flushAndClear();
+
+            // then
+            assertThat(chatMessageService.findByChatRoomId(chatRoomId))
+                    .extracting(ActiveChatRoomResponse.ChatMessageResponse::status)
+                    .containsExactly("SUCCESS", "FAILED", "SUCCESS", "FAILED");
+        }
+    }
+
+    @Nested
+    @DisplayName("findByChatRoomId")
+    class FindByChatRoomId {
+
+        @Test
+        @DisplayName("대화가 없으면 빈 목록을 반환한다")
+        void emptyRoomReturnsEmptyList() {
+            assertThat(chatMessageService.findByChatRoomId(createChatRoom().getId()))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 채팅방의 메시지는 섞이지 않는다")
+        void doesNotLeakOtherRoomMessages() {
+            // given
+            User user = userRepository.save(createUser());
+            Long roomA = chatRoomRepository.save(ChatRoom.builder().user(user).build()).getId();
+            Long roomB = chatRoomRepository.save(ChatRoom.builder().user(user).build()).getId();
+
+            chatMessageService.saveTurn(
+                    roomA,
+                    MemoAiRequest.of("A방 질문", MemoAiOptions.MERGE, List.of(11L)),
+                    MemoAiResponse.of("A제목", "A본문", MemoAiOptions.MERGE, List.of(11L), null));
+            chatMessageService.saveFailedTurn(
+                    roomB, MemoAiRequest.of("B방 질문", MemoAiOptions.MERGE, List.of(12L)));
+            flushAndClear();
+
+            // then
+            assertThat(chatMessageService.findByChatRoomId(roomA))
+                    .extracting(ActiveChatRoomResponse.ChatMessageResponse::content)
+                    .containsExactly("A방 질문", "A본문");
+        }
+
+        @Test
+        @DisplayName("여러 턴은 주고받은 순서대로 반환된다")
+        void returnsMessagesInConversationOrder() {
+            // given
+            Long chatRoomId = createChatRoom().getId();
+
+            chatMessageService.saveTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("첫 질문", MemoAiOptions.MERGE, List.of(11L)),
+                    MemoAiResponse.of("첫 제목", "첫 답변", MemoAiOptions.MERGE, List.of(11L), null));
+            chatMessageService.saveTurn(
+                    chatRoomId,
+                    MemoAiRequest.of("둘째 질문", MemoAiOptions.SUMMARY, List.of(11L)),
+                    MemoAiResponse.of("둘째 제목", "둘째 답변", MemoAiOptions.SUMMARY, List.of(11L), null));
+            flushAndClear();
+
+            // then
+            assertThat(chatMessageService.findByChatRoomId(chatRoomId))
+                    .extracting(ActiveChatRoomResponse.ChatMessageResponse::content)
+                    .containsExactly("첫 질문", "첫 답변", "둘째 질문", "둘째 답변");
+        }
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    private ChatRoom createChatRoom() {
+        return chatRoomRepository.save(
+                ChatRoom.builder().user(userRepository.save(createUser())).build()
+        );
+    }
+
+    private User createUser() {
+        return User.createSocialUser(
+                "test" + UUID.randomUUID() + "@test.com", "테스트 유저", "profile.png", "google");
+    }
+}

--- a/src/test/java/org/project/domain/ai/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/org/project/domain/ai/service/ChatRoomServiceImplTest.java
@@ -7,6 +7,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.dto.response.ChatRoomListResponse;
+import org.project.global.exception.domainException.ChatRoomException;
+import org.project.global.exception.errorcode.ChatRoomErrorCode;
 import org.project.domain.ai.entity.ChatRoom;
 import org.project.domain.ai.repository.ChatRoomRepository;
 import org.project.domain.user.entity.User;
@@ -18,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -133,6 +137,90 @@ class ChatRoomServiceImplTest {
         // then
         assertThat(chatRoom.getIsDeleted()).isTrue();
         verify(chatMemory).clear("user:1:room:7");
+    }
+
+    @Test
+    @DisplayName("채팅방 목록은 삭제되지 않은 방만 반환한다")
+    void findAllByUser_returnsActiveRooms() {
+        // given
+        User user = createUser();
+        when(chatRoomRepository.findAllByUserIdAndIsDeletedFalse(1L))
+                .thenReturn(List.of(
+                        withId(ChatRoom.builder().user(user).build(), 7L),
+                        withId(ChatRoom.builder().user(user).build(), 8L)
+                ));
+
+        // when
+        ChatRoomListResponse response = chatRoomService.findAllByUser(1L);
+
+        // then
+        assertThat(response.chatRooms())
+                .extracting(ChatRoomListResponse.ChatRoomResponse::chatRoomId)
+                .containsExactly(7L, 8L);
+    }
+
+    @Test
+    @DisplayName("최근 채팅방을 조회한다")
+    void findLatestChatRoomByUser_returnsActiveRoom() {
+        // given
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L))
+                .thenReturn(Optional.of(withId(ChatRoom.builder().user(createUser()).build(), 7L)));
+
+        // when & then
+        assertThat(chatRoomService.findLatestChatRoomByUser(1L).chatRoomId()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("채팅방이 하나도 없으면 최근 채팅방 조회는 실패한다")
+    void findLatestChatRoomByUser_noRoom_throws() {
+        // given
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomService.findLatestChatRoomByUser(1L))
+                .isInstanceOf(ChatRoomException.class)
+                .extracting(e -> ((ChatRoomException) e).getErrorCode())
+                .isEqualTo(ChatRoomErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채팅방에 접근하면 CHAT_ROOM_NOT_FOUND를 던진다")
+    void validateAccess_notFound() {
+        // given
+        when(chatRoomRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomService.validateAccess(1L, 99L))
+                .isInstanceOf(ChatRoomException.class)
+                .extracting(e -> ((ChatRoomException) e).getErrorCode())
+                .isEqualTo(ChatRoomErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 채팅방에 접근하면 CHAT_ROOM_ACCESS_DENIED를 던진다")
+    void validateAccess_otherUsersRoom() {
+        // given
+        ChatRoom othersRoom = withId(
+                ChatRoom.builder().user(withUserId(createUser(), 2L)).build(), 7L);
+        when(chatRoomRepository.findById(7L)).thenReturn(Optional.of(othersRoom));
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomService.validateAccess(1L, 7L))
+                .isInstanceOf(ChatRoomException.class)
+                .extracting(e -> ((ChatRoomException) e).getErrorCode())
+                .isEqualTo(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("본인 채팅방이면 그대로 반환한다")
+    void validateAccess_ownRoom() {
+        // given
+        ChatRoom ownRoom = withId(
+                ChatRoom.builder().user(withUserId(createUser(), 1L)).build(), 7L);
+        when(chatRoomRepository.findById(7L)).thenReturn(Optional.of(ownRoom));
+
+        // when & then
+        assertThat(chatRoomService.validateAccess(1L, 7L).getId()).isEqualTo(7L);
     }
 
     private ChatRoom withId(ChatRoom chatRoom, Long id) {

--- a/src/test/java/org/project/domain/ai/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/org/project/domain/ai/service/ChatRoomServiceImplTest.java
@@ -1,0 +1,151 @@
+package org.project.domain.ai.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.ai.dto.response.ActiveChatRoomResponse;
+import org.project.domain.ai.entity.ChatRoom;
+import org.project.domain.ai.repository.ChatRoomRepository;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatRoomService 테스트")
+class ChatRoomServiceImplTest {
+
+    @InjectMocks
+    private ChatRoomServiceImpl chatRoomService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private ChatMemory chatMemory;
+
+    @Test
+    @DisplayName("활성 채팅방이 없으면 새로 생성하고 빈 대화를 반환한다")
+    void getActiveConversation_noRoom_createsRoomAndReturnsEmptyMessages() {
+        // given
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L))
+                .thenReturn(Optional.empty());
+        when(userRepository.getReferenceById(1L)).thenReturn(createUser());
+        when(chatRoomRepository.save(any(ChatRoom.class)))
+                .thenAnswer(invocation -> withId(invocation.getArgument(0), 7L));
+
+        // when
+        ActiveChatRoomResponse response = chatRoomService.getActiveConversation(1L);
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(7L);
+        assertThat(response.messages()).isEmpty();
+        verify(chatMessageService, never()).findByChatRoomId(anyLong());
+    }
+
+    @Test
+    @DisplayName("활성 채팅방이 있으면 새로 만들지 않고 기존 대화를 반환한다")
+    void getActiveConversation_roomExists_returnsExistingMessages() {
+        // given
+        ChatRoom existing = withId(ChatRoom.builder().user(createUser()).build(), 7L);
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L))
+                .thenReturn(Optional.of(existing));
+        when(chatMessageService.findByChatRoomId(7L))
+                .thenReturn(List.of(
+                        new ActiveChatRoomResponse.ChatMessageResponse(
+                                1L, "USER", "SUCCESS", null, "질문", null, List.of(), null)
+                ));
+
+        // when
+        ActiveChatRoomResponse response = chatRoomService.getActiveConversation(1L);
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(7L);
+        assertThat(response.messages()).hasSize(1);
+        verify(chatRoomRepository, never()).save(any(ChatRoom.class));
+    }
+
+    @Test
+    @DisplayName("새 대화를 시작하면 기존 활성 채팅방을 삭제하고 ChatMemory를 정리한다")
+    void create_existingRoom_softDeletesAndClearsChatMemory() {
+        // given
+        ChatRoom existing = withId(ChatRoom.builder().user(createUser()).build(), 7L);
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L))
+                .thenReturn(Optional.of(existing));
+        when(userRepository.getReferenceById(1L)).thenReturn(createUser());
+        when(chatRoomRepository.save(any(ChatRoom.class)))
+                .thenAnswer(invocation -> withId(invocation.getArgument(0), 8L));
+
+        // when
+        ChatRoom created = chatRoomService.create(1L);
+
+        // then
+        assertThat(existing.getIsDeleted()).isTrue();
+        assertThat(created.getId()).isEqualTo(8L);
+        verify(chatMemory).clear("user:1:room:7");
+    }
+
+    @Test
+    @DisplayName("기존 활성 채팅방이 없으면 ChatMemory 정리 없이 새 채팅방만 생성한다")
+    void create_noExistingRoom_doesNotClearChatMemory() {
+        // given
+        when(chatRoomRepository.findTopByUserIdOrderByIdDesc(1L))
+                .thenReturn(Optional.empty());
+        when(userRepository.getReferenceById(1L)).thenReturn(createUser());
+        when(chatRoomRepository.save(any(ChatRoom.class)))
+                .thenAnswer(invocation -> withId(invocation.getArgument(0), 8L));
+
+        // when
+        chatRoomService.create(1L);
+
+        // then
+        verify(chatMemory, never()).clear(anyString());
+    }
+
+    @Test
+    @DisplayName("채팅방을 삭제하면 ChatMemory도 함께 정리한다")
+    void delete_clearsChatMemory() {
+        // given
+        User user = withUserId(createUser(), 1L);
+        ChatRoom chatRoom = withId(ChatRoom.builder().user(user).build(), 7L);
+        when(chatRoomRepository.findById(7L)).thenReturn(Optional.of(chatRoom));
+
+        // when
+        chatRoomService.delete(1L, 7L);
+
+        // then
+        assertThat(chatRoom.getIsDeleted()).isTrue();
+        verify(chatMemory).clear("user:1:room:7");
+    }
+
+    private ChatRoom withId(ChatRoom chatRoom, Long id) {
+        ReflectionTestUtils.setField(chatRoom, "id", id);
+        return chatRoom;
+    }
+
+    private User withUserId(User user, Long id) {
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private User createUser() {
+        return User.createSocialUser("test@test.com", "테스터", "profile.png", "google");
+    }
+}

--- a/src/test/java/org/project/domain/ai/service/MemoAiServiceImplTest.java
+++ b/src/test/java/org/project/domain/ai/service/MemoAiServiceImplTest.java
@@ -8,6 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.domain.ai.dto.MemoAiOptions;
 import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.request.MemoAiRequestForPlan;
+import org.project.domain.ai.dto.response.AiEvaluationResult;
+import org.project.domain.ai.dto.response.MemoAiResponseForPlan;
 import org.project.domain.ai.dto.response.MemoAiResponse;
 import org.project.domain.ai.rag.pipeline.RagPipeline;
 import org.project.global.exception.InsufficientRagContextException;
@@ -19,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemoAiService 테스트")
@@ -110,5 +114,70 @@ class MemoAiServiceImplTest {
         // when & then
         assertThatThrownBy(() -> memoAiService.generate(1L, 7L, request))
                 .isSameAs(aiFailure);
+    }
+
+    @Test
+    @DisplayName("접근 권한 검증에 실패하면 AI를 호출하지 않는다")
+    void generate_accessDenied_doesNotCallAi() {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L));
+        doThrow(new RuntimeException("권한 없음"))
+                .when(chatRoomService).validateAccess(1L, 7L);
+
+        // when & then
+        assertThatThrownBy(() -> memoAiService.generate(1L, 7L, request))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(ragPipeline, never()).run(any(), any(), any());
+        verify(chatMessageService, never()).saveTurn(any(), any(), any());
+        verify(chatMessageService, never()).saveFailedTurn(any(), any());
+    }
+
+    @Test
+    @DisplayName("[기획용] AI 응답과 품질 평가 결과를 함께 반환한다")
+    void generateForPlan_success() {
+        // given
+        MemoAiRequestForPlan request = new MemoAiRequestForPlan(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L),
+                "system prompt", "gemini-2.5-flash", 0.7);
+
+        MemoAiResponse aiResponse = MemoAiResponse.of(
+                "제목", "본문", MemoAiOptions.MERGE, List.of(11L), null);
+        AiEvaluationResult evaluation = AiEvaluationResult.of(0.9, 0.95, 0.85, true);
+
+        when(ragPipeline.runForPlan(
+                eq(1L), eq(7L), any(MemoAiRequest.class),
+                eq("system prompt"), eq("gemini-2.5-flash"), eq(0.7)))
+                .thenReturn(aiResponse);
+        when(aiEvaluationService.evaluate(eq("정리해줘"), eq(aiResponse)))
+                .thenReturn(evaluation);
+
+        // when
+        MemoAiResponseForPlan response = memoAiService.generateForPlan(1L, 7L, request);
+
+        // then
+        assertThat(response.aiResponse().title()).isEqualTo("제목");
+        assertThat(response.evaluation()).isEqualTo(evaluation);
+    }
+
+    @Test
+    @DisplayName("[기획용] 컨텍스트가 부족하면 평가 없이 안내 응답을 반환한다")
+    void generateForPlan_insufficientContext() {
+        // given
+        MemoAiRequestForPlan request = new MemoAiRequestForPlan(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L),
+                "system prompt", "gemini-2.5-flash", 0.7);
+
+        when(ragPipeline.runForPlan(any(), any(), any(), any(), any(), any()))
+                .thenThrow(new InsufficientRagContextException("메모 내용이 부족합니다"));
+
+        // when
+        MemoAiResponseForPlan response = memoAiService.generateForPlan(1L, 7L, request);
+
+        // then
+        assertThat(response.aiResponse().content()).isEqualTo("메모 내용이 부족합니다");
+        assertThat(response.aiResponse().title()).isEqualTo("AI 응답을 생성할 수 없습니다");
+        verify(aiEvaluationService, never()).evaluate(any(), any());
     }
 }

--- a/src/test/java/org/project/domain/ai/service/MemoAiServiceImplTest.java
+++ b/src/test/java/org/project/domain/ai/service/MemoAiServiceImplTest.java
@@ -1,0 +1,114 @@
+package org.project.domain.ai.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.domain.ai.dto.MemoAiOptions;
+import org.project.domain.ai.dto.request.MemoAiRequest;
+import org.project.domain.ai.dto.response.MemoAiResponse;
+import org.project.domain.ai.rag.pipeline.RagPipeline;
+import org.project.global.exception.InsufficientRagContextException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemoAiService 테스트")
+class MemoAiServiceImplTest {
+
+    @InjectMocks
+    private MemoAiServiceImpl memoAiService;
+
+    @Mock
+    private RagPipeline ragPipeline;
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private AiEvaluationService aiEvaluationService;
+
+    @Test
+    @DisplayName("AI 응답이 생성되면 사용자 프롬프트와 AI 응답을 저장한다")
+    void generate_success_savesTurn() {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(
+                "이 메모들 정리해줘", MemoAiOptions.MERGE, List.of(11L, 12L)
+        );
+        MemoAiResponse aiResponse = MemoAiResponse.of(
+                "주간 회의 정리", "본문", MemoAiOptions.MERGE, List.of(11L, 12L), null
+        );
+        when(ragPipeline.run(1L, 7L, request)).thenReturn(aiResponse);
+
+        // when
+        MemoAiResponse response = memoAiService.generate(1L, 7L, request);
+
+        // then
+        assertThat(response.title()).isEqualTo("주간 회의 정리");
+        verify(chatMessageService).saveTurn(7L, request, aiResponse);
+    }
+
+    @Test
+    @DisplayName("컨텍스트가 부족해 안내 응답으로 대체되어도 화면에 노출되므로 저장한다")
+    void generate_insufficientContext_savesFallbackTurn() {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L)
+        );
+        when(ragPipeline.run(1L, 7L, request))
+                .thenThrow(new InsufficientRagContextException("메모 내용이 부족합니다"));
+
+        // when
+        MemoAiResponse response = memoAiService.generate(1L, 7L, request);
+
+        // then
+        assertThat(response.content()).isEqualTo("메모 내용이 부족합니다");
+        verify(chatMessageService).saveTurn(eq(7L), eq(request), any(MemoAiResponse.class));
+    }
+
+    @Test
+    @DisplayName("AI 호출이 실패하면 실패한 턴을 저장하고 예외를 그대로 던진다")
+    void generate_pipelineThrows_savesFailedTurnAndRethrows() {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L)
+        );
+        RuntimeException failure = new RuntimeException("Gemini 호출 실패");
+        when(ragPipeline.run(1L, 7L, request)).thenThrow(failure);
+
+        // when & then
+        assertThatThrownBy(() -> memoAiService.generate(1L, 7L, request))
+                .isSameAs(failure);
+
+        verify(chatMessageService).saveFailedTurn(7L, request);
+        verify(chatMessageService, never()).saveTurn(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("실패 턴 저장이 실패해도 원래 AI 예외를 그대로 던진다")
+    void generate_saveFailedTurnThrows_stillRethrowsOriginal() {
+        // given
+        MemoAiRequest request = MemoAiRequest.of(
+                "정리해줘", MemoAiOptions.MERGE, List.of(11L)
+        );
+        RuntimeException aiFailure = new RuntimeException("Gemini 호출 실패");
+        when(ragPipeline.run(1L, 7L, request)).thenThrow(aiFailure);
+        doThrow(new RuntimeException("DB 저장 실패"))
+                .when(chatMessageService).saveFailedTurn(7L, request);
+
+        // when & then
+        assertThatThrownBy(() -> memoAiService.generate(1L, 7L, request))
+                .isSameAs(aiFailure);
+    }
+}

--- a/src/test/java/org/project/global/util/MemoContentParserTest.java
+++ b/src/test/java/org/project/global/util/MemoContentParserTest.java
@@ -1,0 +1,70 @@
+package org.project.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.global.exception.domainException.AiException;
+import org.project.global.exception.errorcode.AiErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("MemoContentParser 테스트")
+class MemoContentParserTest {
+
+    @Test
+    @DisplayName("첫 줄을 제목으로, 나머지를 본문으로 분리한다")
+    void parseTitleAndContent_success() {
+        // when
+        MemoContentParser.ParsedMemoContent parsed =
+                MemoContentParser.parseTitleAndContent("주간 회의 정리\n\n본문 첫 줄\n본문 둘째 줄");
+
+        // then
+        assertThat(parsed.title()).isEqualTo("주간 회의 정리");
+        assertThat(parsed.content()).isEqualTo("본문 첫 줄\n본문 둘째 줄");
+    }
+
+    @Test
+    @DisplayName("AI가 형식을 어겨 한 줄로 응답하면 재시도 가능한 503으로 처리한다")
+    void parseTitleAndContent_singleLine_isRetryableServerError() {
+        assertThatThrownBy(() ->
+                MemoContentParser.parseTitleAndContent("정리할 내용이 없습니다"))
+                .isInstanceOf(AiException.class)
+                .extracting(e -> ((AiException) e).getErrorCode().getStatus())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("AI 응답이 null이면 재시도 가능한 503으로 처리한다")
+    void parseTitleAndContent_null_isRetryableServerError() {
+        assertThatThrownBy(() -> MemoContentParser.parseTitleAndContent(null))
+                .isInstanceOf(AiException.class)
+                .extracting(e -> ((AiException) e).getErrorCode().getStatus())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("AI 응답이 비어 있으면 재시도 가능한 503으로 처리한다")
+    void parseTitleAndContent_blank_isRetryableServerError() {
+        assertThatThrownBy(() -> MemoContentParser.parseTitleAndContent("   \n  "))
+                .isInstanceOf(AiException.class)
+                .extracting(e -> ((AiException) e).getErrorCode().getStatus())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("AI 응답 형식 오류는 사용자가 읽을 수 있는 안내 문구를 사용한다")
+    void aiResponseFormatErrors_haveUserFacingMessage() {
+        for (AiErrorCode code : new AiErrorCode[]{
+                AiErrorCode.AI_RESPONSE_NULL,
+                AiErrorCode.AI_RESPONSE_EMPTY,
+                AiErrorCode.AI_TITLE_EXTRACTION_FAILED,
+                AiErrorCode.AI_TITLE_EMPTY
+        }) {
+            assertThat(code.getMsg())
+                    .as("%s 의 메시지", code)
+                    .doesNotContain("null")
+                    .contains("다시 시도");
+        }
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #189

## 📝 Summary

AI 패널을 닫았다 열거나 새로고침해도 기존 대화가 유지되도록 대화 저장/조회 API를 구현했습니다.
기획안에 채팅방 목록 UI가 없고 "새 대화 시작 = 기존 대화 삭제"로 정의되어 있어 **유저당 활성 채팅방 1개** 모델로 구성했습니다.

**신규 API**
- `GET /api/v1/chat-rooms/active` — 패널 진입용. 활성 채팅방과 대화를 함께 반환하고, 방이 없으면 생성해 빈 대화를 줍니다

**기존 API 수정** (URL·요청·응답 형식 변경 없음)
- `POST /chat-rooms` — 새 대화 시작 동작으로 변경. 기존 방 soft delete + ChatMemory 정리 + 새 방 생성을 한 트랜잭션으로
- `POST /chat-rooms/{id}/chat` — 응답 성공 시 대화 저장. AI 호출 실패도 FAILED 턴으로 남겨 재시도 가능
- `DELETE /chat-rooms/{id}` — 누락돼 있던 ChatMemory 정리 보완

**저장 구조**
- `chat_message` 테이블 신설. `spring_ai_chat_memory`는 윈도우 초과분을 물리 삭제하고 구조 정보도 없어 화면 복원용으로 쓸 수 없습니다
- 사용자 메시지에 `option`/`memoIds`를 함께 보관해, 실패한 턴을 드래그한 메모까지 그대로 재시도할 수 있습니다

## 🙏 Question & PR point

### 데이터가 쌓였을 때 필요한 후속 작업

이번 구현은 대화를 계속 누적하는 구조입니다. 새 대화를 시작해도 이전 메시지를 지우지 않고, 실패한 턴도 함께 남기기 때문에 `chat_message`는 단조 증가합니다. 지금은 규모가 작아 문제가 없지만, 사용량이 늘면 아래 순서로 대응하면 됩니다.

**인덱스 추가** 

현재 `chat_message`와 `chat_room` 모두 PK 인덱스만 있습니다. PostgreSQL은 외래키에 인덱스를 자동 생성하지 않아, 패널을 열 때마다 실행되는 두 쿼리가 순차 스캔으로 동작합니다.

```sql
-- 대화 조회: WHERE chat_room_id = ? ORDER BY chat_message_id ASC
CREATE INDEX idx_chat_message_room_id
    ON chat_message (chat_room_id, chat_message_id);

-- 활성 채팅방 조회: WHERE user_id = ? AND is_deleted = false ORDER BY chat_room_id DESC LIMIT 1
CREATE INDEX idx_chat_room_active
    ON chat_room (user_id, chat_room_id DESC)
    WHERE is_deleted = false;
```
chat_message는 복합으로 걸어야 정렬 단계까지 사라집니다. chat_room은 삭제된 방이 계속 쌓이므로 부분 인덱스가 유리하지만, @Index로는 표현할 수 없어 SQL로 적용해야 합니다.

페이지네이션 — GET /chat-rooms/active가 활성 채팅방의 전체 메시지를 반환합니다. 커서 방식이나 최근 N턴 제한이 필요하며 프론트 무한 스크롤과 함께 설계해야 합니다.

정리 배치 — 채팅방은 soft delete만 하고 메시지는 남기므로, 이슈 #182처럼 오래된 삭제 채팅방과 메시지를 물리 삭제하는 배치가 필요합니다.

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 활성 채팅방과 전체 대화 내역을 조회하는 API를 추가했습니다.
  * 채팅 메시지와 AI 응답 상태를 저장하고 불러올 수 있습니다.
  * AI 응답 실패 시에도 사용자 요청과 실패 상태가 대화에 기록됩니다.
  * 새 채팅방 생성 또는 삭제 시 기존 대화가 정리됩니다.
  * AI 대화 메모리 보관 개수를 설정할 수 있습니다.

* **개선 사항**
  * 기존 최신 채팅방 조회 API를 더 안정적인 기준으로 개선하고 사용 중단을 안내합니다.
  * 메모 AI 요청의 빈 프롬프트 검증을 강화했습니다.

* **테스트**
  * 활성 대화 조회, 메시지 저장, 실패 처리 및 입력 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->