### PR TITLE
[Fix] 태그 저장시 오류 해결

### DIFF
--- a/src/main/java/org/project/domain/memo/entity/MemoTag.java
+++ b/src/main/java/org/project/domain/memo/entity/MemoTag.java
@@ -38,4 +38,8 @@ public class MemoTag {
                 .tagPriority(tagPriority)
                 .build();
     }
+
+    public void updatePriority(Integer tagPriority) {
+        this.tagPriority = tagPriority;
+    }
 }

--- a/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
+++ b/src/main/java/org/project/domain/memo/service/MemoServiceImpl.java
@@ -14,6 +14,7 @@ import org.project.domain.memo.dto.response.*;
 import org.project.domain.memo.entity.Memo;
 import org.project.domain.memo.entity.MemoFile;
 import org.project.domain.memo.entity.MemoImage;
+import org.project.domain.memo.entity.MemoTag;
 import org.project.domain.memo.event.MemoAttachmentsRemovedEvent;
 import org.project.domain.memo.event.MemoDeletedEvent;
 import org.project.domain.memo.event.MemoFileCreatedEvent;
@@ -173,7 +174,7 @@ public class MemoServiceImpl implements MemoService {
         );
 
         // 태그 처리 (중복 제거 + 우선순위)
-        attachTags(memo, request.tagNames(), user);
+        syncTags(memo, request.tagNames(), user);
 
         // 메모 저장
         Memo savedMemo = memoRepository.save(memo);
@@ -238,8 +239,7 @@ public class MemoServiceImpl implements MemoService {
         //    순서=우선순위라 순서 민감 비교. 태그는 임베딩에 영향 없음.
         List<String> currentTagNames = memo.getTags().stream().map(Tag::getName).toList();
         if (!currentTagNames.equals(request.tagNames())) {
-            memo.getMemoTags().clear();
-            attachTags(memo, request.tagNames(), user);
+            syncTags(memo, request.tagNames(), user);
         }
 
         // 3) 첨부(이미지/파일) diff — 유지/추가/삭제
@@ -427,7 +427,7 @@ public class MemoServiceImpl implements MemoService {
                 sourceMemoIds
         );
 
-        attachTags(memo, resolveCommonTagNames(sourceMemos), user);
+        syncTags(memo, resolveCommonTagNames(sourceMemos), user);
 
         Memo savedMemo = memoRepository.save(memo);
 
@@ -768,23 +768,58 @@ public class MemoServiceImpl implements MemoService {
                 .orElseThrow(() -> new MemoException(MemoErrorCode.MEMO_NOT_FOUND));
     }
 
-    // 태그 처리 (중복 제거 + 우선순위) — 이름 목록으로 기존 태그 일괄 조회 후, 없는 것만 일괄 생성
-    private void attachTags(Memo memo, List<String> tagNames, User user) {
-        if (tagNames == null || tagNames.isEmpty()) {
+    // 요청으로 온 태그 최종 상태를 메모에 반영한다 (유지=우선순위만 갱신, 추가=신규 생성, 빠진 것=삭제)
+    private void syncTags(Memo memo, List<String> tagNames, User user) {
+        List<String> desired = (tagNames == null)
+                ? List.of()
+                : tagNames.stream().distinct().toList();
+
+        if (desired.isEmpty()) {
+            memo.getMemoTags().clear();
             return;
         }
 
-        List<String> uniqueTagNames = tagNames.stream()
-                .distinct()
-                .toList();
+        Map<String, Tag> tagsByName = findOrCreateTags(desired, user);
 
-        Map<String, Tag> tagsByName = findOrCreateTags(uniqueTagNames, user);
+        // 삭제 = 현재 - 최종. 유지되는 행은 건드리지 않는다.
+        Set<String> desiredNames = Set.copyOf(desired);
+        memo.getMemoTags().removeIf(memoTag -> !desiredNames.contains(memoTag.getTag().getName()));
 
-        for (int priority = 0; priority < uniqueTagNames.size(); priority++) {
-            String tagName = uniqueTagNames.get(priority);
-            memo.addTag(tagsByName.get(tagName), priority);
+        Map<String, MemoTag> keptByName = memo.getMemoTags().stream()
+                .collect(Collectors.toMap(memoTag -> memoTag.getTag().getName(), Function.identity()));
+
+        for (int priority = 0; priority < desired.size(); priority++) {
+            String name = desired.get(priority);
+            MemoTag kept = keptByName.get(name);
+
+            if (kept != null) {
+                kept.updatePriority(priority);
+            } else {
+                memo.addTag(tagsByName.get(name), priority);
+            }
         }
+
+        // @OrderBy는 DB에서 로드할 때만 적용되므로, 같은 트랜잭션에서도 최종 순서가 보이도록 맞춘다.
+        memo.getMemoTags().sort(Comparator.comparing(MemoTag::getTagPriority));
     }
+
+    // 태그 처리 (중복 제거 + 우선순위) — syncTags로 대체됨
+//    private void attachTags(Memo memo, List<String> tagNames, User user) {
+//        if (tagNames == null || tagNames.isEmpty()) {
+//            return;
+//        }
+//
+//        List<String> uniqueTagNames = tagNames.stream()
+//                .distinct()
+//                .toList();
+//
+//        Map<String, Tag> tagsByName = findOrCreateTags(uniqueTagNames, user);
+//
+//        for (int priority = 0; priority < uniqueTagNames.size(); priority++) {
+//            String tagName = uniqueTagNames.get(priority);
+//            memo.addTag(tagsByName.get(tagName), priority);
+//        }
+//    }
 
     private Map<String, Tag> findOrCreateTags(List<String> tagNames, User user) {
         List<Tag> existingTags = tagRepository.findAllByNameInAndUser(tagNames, user);
@@ -797,8 +832,8 @@ public class MemoServiceImpl implements MemoService {
                 .toList();
 
         if (!newTags.isEmpty()) {
-            tagRepository.saveAll(newTags)
-                    .forEach(tag -> tagsByName.put(tag.getName(), tag));
+            tagRepository.saveAll(newTags);
+            newTags.forEach(tag -> tagsByName.put(tag.getName(), tag));
         }
 
         return tagsByName;

--- a/src/test/java/org/project/domain/memo/service/MemoTagSyncTest.java
+++ b/src/test/java/org/project/domain/memo/service/MemoTagSyncTest.java
@@ -1,0 +1,181 @@
+package org.project.domain.memo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.domain.memo.dto.request.MemoCreateRequest;
+import org.project.domain.memo.dto.request.MemoUpdateRequest;
+import org.project.domain.memo.entity.Memo;
+import org.project.domain.memo.entity.MemoTag;
+import org.project.domain.memo.repository.MemoRepository;
+import org.project.domain.tag.entity.Tag;
+import org.project.domain.tag.repository.TagRepository;
+import org.project.domain.user.entity.User;
+import org.project.domain.user.repository.UserRepository;
+import org.project.global.config.vectorstore.TestVectorStoreConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestVectorStoreConfig.class)
+@DisplayName("메모 태그 동기화")
+class MemoTagSyncTest {
+
+    @Autowired private MemoService memoService;
+    @Autowired private MemoRepository memoRepository;
+    @Autowired private TagRepository tagRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = userRepository.save(User.createSocialUser(
+                "tag-sync-" + UUID.randomUUID() + "@test.com",
+                "태그유저",
+                "profile.png",
+                "google"
+        )).getId();
+    }
+
+    private Long createMemo(List<String> tagNames) {
+        return memoService.createMemo(
+                userId,
+                new MemoCreateRequest("제목", "내용", tagNames, List.of(), List.of())
+        ).memoId();
+    }
+
+    private void updateTags(Long memoId, List<String> tagNames) {
+        memoService.updateMemo(
+                userId,
+                memoId,
+                new MemoUpdateRequest("제목", "내용", tagNames, List.of(), List.of())
+        );
+    }
+
+    // 저장된 태그를 우선순위 순서대로 읽는다
+    private List<String> savedTagNames(Long memoId) {
+        return transactionTemplate.execute(status -> {
+            Memo memo = memoRepository.findByIdAndNotDeleted(memoId).orElseThrow();
+            return memo.getMemoTags().stream()
+                    .map(MemoTag::getTag)
+                    .map(Tag::getName)
+                    .toList();
+        });
+    }
+
+    @Test
+    @DisplayName("태그를 하나만 붙였다 다른 태그로 바꾸면 반영된다")
+    void 태그_한개_교체() {
+        Long memoId = createMemo(List.of("A"));
+
+        updateTags(memoId, List.of("B"));
+
+        assertThat(savedTagNames(memoId)).containsExactly("B");
+    }
+
+    @Test
+    @DisplayName("태그가 붙어 있는 메모에 태그를 하나 더 붙일 수 있다")
+    void 태그_추가() {
+        Long memoId = createMemo(List.of("A"));
+
+        assertThatCode(() -> updateTags(memoId, List.of("A", "B")))
+                .doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("태그 여러 개 중 하나만 뗄 수 있다")
+    void 태그_일부_삭제() {
+        Long memoId = createMemo(List.of("A", "B", "C"));
+
+        assertThatCode(() -> updateTags(memoId, List.of("A", "B")))
+                .doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("유지·추가·삭제가 한 번에 섞여도 반영된다")
+    void 태그_혼합_변경() {
+        Long memoId = createMemo(List.of("A", "B", "C"));
+
+        assertThatCode(() -> updateTags(memoId, List.of("A", "B", "D")))
+                .doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("A", "B", "D");
+    }
+
+    @Test
+    @DisplayName("태그 순서를 바꾸면 우선순위가 갱신된다")
+    void 태그_순서_변경() {
+        Long memoId = createMemo(List.of("A", "B"));
+
+        assertThatCode(() -> updateTags(memoId, List.of("B", "A")))
+                .doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("B", "A");
+    }
+
+    @Test
+    @DisplayName("태그를 모두 떼면 빈 목록이 된다")
+    void 태그_전체_삭제() {
+        Long memoId = createMemo(List.of("A", "B"));
+
+        updateTags(memoId, List.of());
+
+        assertThat(savedTagNames(memoId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 태그 목록을 반복해서 보내도(자동저장) 실패하지 않는다")
+    void 자동저장_반복() {
+        Long memoId = createMemo(List.of("A", "B"));
+
+        assertThatCode(() -> {
+            updateTags(memoId, List.of("A", "B"));
+            updateTags(memoId, List.of("A", "B"));
+            updateTags(memoId, List.of("A", "B"));
+        }).doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("중복된 태그 이름이 섞여 와도 한 번만 저장된다")
+    void 중복_이름_요청() {
+        Long memoId = createMemo(List.of("A"));
+
+        assertThatCode(() -> updateTags(memoId, List.of("A", "A", "B")))
+                .doesNotThrowAnyException();
+
+        assertThat(savedTagNames(memoId)).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("태그는 사용자당 이름이 유일해 재사용된다")
+    void 태그_재사용() {
+        Long memo1 = createMemo(List.of("공용"));
+        Long memo2 = createMemo(List.of());
+
+        updateTags(memo2, List.of("공용"));
+
+        assertThat(tagRepository.findAllByNameInAndUser(
+                List.of("공용"), userRepository.findById(userId).orElseThrow()))
+                .hasSize(1);
+        assertThat(savedTagNames(memo1)).containsExactly("공용");
+        assertThat(savedTagNames(memo2)).containsExactly("공용");
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- close #191

## 📝 Summary

**문제**: 메모에 태그를 2개 이상 붙이면 자동저장이 `500 "DB 제약조건 문제 발생"`으로 실패

기존 태그 수정 로직이 `clear()` 후 전체 재부착 방식이었는데, Hibernate가 같은 flush 안에서 **INSERT를 orphan DELETE보다 먼저** 실행합니다. 그래서 유지되는 태그가 하나라도 있으면 아직 안 지워진 기존 행과 충돌하는 것이 문제

**"기존 태그가 하나라도 유지되면"** 실패됨 조건이었습니다.

**해결**: `attachTags` → `syncTags`로 교체. 전체를 지웠다 다시 넣지 않고, **최종 상태와 diff만 반영**합니다.

- 유지되는 태그 → `tagPriority`만 갱신 (행을 건드리지 않음)
- 빠진 태그 → 삭제
- 새 태그 → 추가

재삽입 자체가 없으므로 flush 순서와 무관하게 안전합니다. 이미지·파일이 이미 쓰고 있던 diff 방식과 같은 접근입니다.

부수적으로, 프론트가 중복된 태그 이름을 보낼 때 자동저장마다 태그를 지웠다 다시 넣던 것도 없어졌습니다(`syncTags`는 멱등).

## 🙏 Question & PR point
- `attachTags`는  주석처리 해뒀습니다.


## 📬 Postman

<!-- postman 스크린샷 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메모 태그를 요청된 최종 목록에 맞춰 자동 동기화합니다.
  * 태그 추가·삭제·교체 및 우선순위 변경을 지원합니다.
  * 태그가 없으면 메모에서 모든 태그가 제거됩니다.
  * 태그 순서가 안정적으로 유지됩니다.
  * 기존 태그를 재사용하고 중복 태그를 방지합니다.

* **버그 수정**
  * 메모 수정 시 태그 변경 사항이 정확히 반영됩니다.

* **테스트**
  * 태그 동기화, 순서 변경, 전체 삭제 및 반복 저장 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->